### PR TITLE
Make gameloop simpler, and fix #194

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -217,12 +217,14 @@ pub trait Game {
             }
 
             // Wait if possible
-            if next_render - time::precise_time_ns() > 2_000_000 { 
-                // Sleeps for 1-2 milisecond's less then needed for correction,
-                // It is better to be fast then slow, and it is safer to round into the range
-                // 1-2 then 0-1 because I don't trust the OS to wake me accurately.
-                sleep( (next_render - time::precise_time_ns() )/1_000_000 - 1 );
+
+            let t = (next_render - time::precise_time_ns() ) / 1_000_000;
+            if t > 1 && t < 1000000 { // The second half just checks if it overflowed,
+                                      // which tells us that t should have been negative 
+                                      // and we are running slow and shouldn't sleep.
+                sleep( t );
             }
+
         }
     }
 }


### PR DESCRIPTION
I pushed all the logic away from the rendering code into the update while condition, and a wait condition afterwards. The main motivation for this was making it easier to see how the code behaves, and modify it without breaking things. 

This utilizes sleep for waiting instead of burning cpu cycles, at the cost of accuracy. Accuracy could be re-introduced with a while loop below it if there is a good reason to, I am just not aware of a good reason.

This fixes #194 by only updating to the update before catching up/passing next_render.
