### PR TITLE
This fixes #360 and #356 and #355 and #353

### DIFF
--- a/examples/soundstream.rs
+++ b/examples/soundstream.rs
@@ -23,14 +23,8 @@ use piston::{
     KeyPress,
     KeyPressArgs,
     SoundStream,
-    soundstreamer
+    SoundStreamSettings
 };
-
-//------------------------------
-
-static SAMPLE_RATE: f64 = 44100f64;
-static NUM_FRAMES: u32 = 1024u32;
-static NUM_CHANNELS: i32 = 2i32;
 
 // Structs
 //------------------------------
@@ -69,8 +63,8 @@ impl Game for App {
         // Create the soundstream on it's own thread for non-blocking, real-time audio.
         // "soundstreamer" will setup and iterate soundstream using portaudio.
         spawn(proc() {
-            let mut soundstream = AppSoundStream::new(Some(recv));
-            soundstreamer(SAMPLE_RATE, NUM_FRAMES, NUM_CHANNELS, &mut soundstream);
+            let mut soundstream =
+                AppSoundStream::new(Some(recv)).run(SoundStreamSettings::cd_quality());
         });
 
     }
@@ -120,20 +114,20 @@ impl SoundStream for AppSoundStream {
     }
 
     /// Update (gets called prior to audio_in/audio_out).
-    fn update(&mut self, dt: u64) {
+    fn update(&mut self, settings: &SoundStreamSettings, dt: u64) {
         if self.is_print {
             let dtsec: f64 = dt as f64 / 1000000000f64;
-            println!("Real-time sample rate: {}", (1f64 / dtsec) * NUM_FRAMES as f64);
+            println!("Real-time sample rate: {}", (1f64 / dtsec) * settings.frames as f64);
         }
     }
 
     /// AudioInput
-    fn audio_in(&mut self, input: &Vec<f32>, num_frames: u32, num_channels: i32) {
+    fn audio_in(&mut self, input: &Vec<f32>, settings: &SoundStreamSettings) {
         self.buffer = input.clone();
     }
 
     /// AudioOutput
-    fn audio_out(&mut self, output: &mut Vec<f32>, num_frames: u32, num_channels: i32) {
+    fn audio_out(&mut self, output: &mut Vec<f32>, settings: &SoundStreamSettings) {
         *output = self.buffer.clone()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ extern crate portaudio;
 
 pub use Game = game::Game;
 pub use SoundStream = sound_stream::SoundStream;
+pub use SoundStreamSettings = sound_stream::SoundStreamSettings;
 
 pub use Render = game_iterator::Render;
 pub use Update = game_iterator::Update;
@@ -59,8 +60,7 @@ pub use AudioBackEnd = audio_back_end::AudioBackEnd;
 pub use AudioSDL2 = sdl2_audio_back_end::AudioSDL2;
 pub use MusicSDL2 = sdl2_audio_back_end::MusicSDL2;
 pub use SoundSDL2 = sdl2_audio_back_end::SoundSDL2;
-#[cfg(port_audio)]
-pub use soundstreamer = pa_audio_back_end::soundstreamer;
+//#[cfg(port_audio)]
 
 pub mod shader_utils;
 pub mod game_window;
@@ -83,4 +83,4 @@ mod sound;
 mod audio_back_end;
 mod sdl2_audio_back_end;
 #[cfg(port_audio)]
-mod pa_audio_back_end;
+mod port_audio_back_end;

--- a/src/sound_stream.rs
+++ b/src/sound_stream.rs
@@ -14,6 +14,50 @@ use MousePressArgs;
 use MouseRelease;
 use MouseReleaseArgs;
 
+use port_audio_back_end::StreamPA;
+use time::precise_time_ns;
+
+
+/// Settings required for SoundStream.
+pub struct SoundStreamSettings {
+    /// The number of samples per second.
+    pub samples_per_second: f64,
+
+    /// How many samples per channel requested at a time in the buffer.
+    /// The more frames, the less likely to make glitches,
+    /// but this gives slower response.
+    pub frames: u32,
+    
+    /// Number of channels, for example 2 for stereo sound (left + right speaker).
+    pub channels: i32
+}
+
+impl SoundStreamSettings {
+    /// Custom constructor for the SoundStreamSettings.
+    ///
+    /// ToDo: It would be good to include a method that checked
+    /// the feasibility of the requested settings (i.e. that
+    /// channels isn't 500, and that samples_per_second and frames
+    /// are of a sound card standard).
+    pub fn new(samples_per_second: f64, frames: u32, channels: i32)
+        -> SoundStreamSettings {
+        SoundStreamSettings {
+            samples_per_second: samples_per_second,
+            frames: frames,
+            channels: channels
+        }
+    }
+    /// Default, standard constructor for SoundStreamSettings.
+    pub fn cd_quality() -> SoundStreamSettings {
+        SoundStreamSettings {
+            samples_per_second: 44100f64,
+            frames: 512u32,
+            channels: 2i32
+        }
+    }
+}
+
+
 /// Implement this for your real-time audio IO engine.
 pub trait SoundStream {
 
@@ -21,7 +65,7 @@ pub trait SoundStream {
     fn load(&mut self) {}
 
     /// Update the physical state of the SoundStream.
-    fn update(&mut self, _dt: u64) {}
+    fn update(&mut self, settings: &SoundStreamSettings, dt: u64) {}
 
     /// User pressed a key.
     ///
@@ -48,12 +92,12 @@ pub trait SoundStream {
     /// Offers input via buffer of interleaved f32 samples (amplitude between -1 to 1).
     /// The input buffer's size is num_frames * num_channels.
     /// Get's called at a rate of (sample_rate / num_frames)hz.
-    fn audio_in(&mut self, _input: &Vec<f32>,  _num_frames: u32, _num_channels: i32) {}
+    fn audio_in(&mut self, _input: &Vec<f32>, settings: &SoundStreamSettings) {}
 
     /// Requests output via buffer as interleaved f32 samples (amplitude between -1 to 1).
     /// The output buffer's size is num_frames * num_channels.
     /// Get's called at a rate of (sample_rate / num_frames)hz.
-    fn audio_out(&mut self, _output: &mut Vec<f32>,  _num_frames: u32, _num_channels: i32) {}
+    fn audio_out(&mut self, _output: &mut Vec<f32>, settings: &SoundStreamSettings) {}
 
     /// Override this using a Receiver<GameEvent> to receive GameEvents from main app.
     fn check_for_event(&self) -> Option<GameEvent> { None }
@@ -72,6 +116,37 @@ pub trait SoundStream {
             MouseRelativeMove(ref args) => self.mouse_relative_move(args),
             _ => {},
         }
+    }
+
+    /// Executes the SoundStream loop.
+    fn run(&mut self, settings: SoundStreamSettings) {
+        let mut stream_pa = StreamPA::new();
+        stream_pa.setup(&settings);
+        //stream_pa.run(settings, self);
+        self.load();
+        stream_pa.start();
+        let mut last_time: u64 = precise_time_ns();
+        let mut this_time: u64;
+        let mut diff_time: u64;
+        loop {
+            let event = self.check_for_event();
+            match event {
+                Some(mut e) => self.event(&mut e),
+                None => ()
+            }
+            this_time = precise_time_ns();
+            diff_time = this_time - last_time;
+            last_time = this_time;
+            self.update(&settings, diff_time);
+            if self.exit() {
+                stream_pa.is_streaming.set(false);
+                break;
+            }
+            else if stream_pa.is_streaming.get() {
+                stream_pa.callback(&settings, self);
+            }
+        }
+        stream_pa.stop();
     }
 
 }


### PR DESCRIPTION
## Summary
- Renamed `pa_audio_back_end` to `port_audio_back_end`.
- Created `SoundStreamSettings` struct to hold `samples_per_second`, `frames` and `channels`.
- Removed `soundstreamer` and `StreamPA`'s run method - replaced with `.run(settings: SoundStreamSettings)` method in `SoundStream`.
- Fixed example to take on new changes.
