### PR TITLE
Early Cargo config file added.  Closes #413

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,16 @@
 name = "piston"
 version = "0.0.0"
 authors = [
-    "bvssvni@gmail.com",
-    "coeuvre@gmail.com",
-    "info@leonkunert.de",
-    "me@michellnordine.com",
-    "ty@pre-alpha.com"]
+    "bvssvni <bvssvni@gmail.com>",
+    "Coeuvre <coeuvre@gmail.com>",
+    "gmorenz",
+    "leonkunert <info@leonkunert.de>",
+    "mitchmindtree <me@michellnordine.com>",
+    "Christiandh",
+    "Apointos",
+    "ccgn",
+    "reem",
+    "TyOverby <ty@pre-alpha.com>"]
 
 [dependencies.gl-rs]
 


### PR DESCRIPTION
Right now all of the dependencies build and link correctly.  I do not expect for this to be common until we can specify a git tag or revision number for our dependencies.  We should not recommend the use of Cargo until this feature is added to Cargo.
