### PR TITLE
Add travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: c
+before_install:
+    - curl -O http://static.rust-lang.org/dist/rust-nightly-x86_64-unknown-linux-gnu.tar.gz
+    - tar xfz rust-nightly-x86_64-unknown-linux-gnu.tar.gz
+    - (cd rust-nightly-x86_64-unknown-linux-gnu/ && sudo ./install.sh)
+    - git clone --recursive https://github.com/rust-lang/cargo
+    - cd cargo
+    - make && sudo make install
+    - cd -
+install:
+script:
+    - cargo build --verbose


### PR DESCRIPTION
In order to more effectively track the build status of individual Piston Projects, Travis-CI should track this project on its own.
