### PR TITLE
Implement Ord, PartialOrd, Eq, PartialEq by hand

### DIFF
--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -249,7 +249,6 @@ pub enum Key {
 }
 
 
-//#[deriving(Clone, PartialEq, PartialOrd, Ord, Eq, Show)]
 impl PartialEq for Key {
     fn eq(&self, other: &Key) -> bool {
         return (*self as i32) == (*other as i32);


### PR DESCRIPTION
There is a bug in rustc that causes code explosion when auto-implementing PartialOrd.  https://github.com/rust-lang/rust/issues/15375

Until those issues are fixed, I've implemented them by hand.

Closes #467 
