### PR TITLE
Fix Travis CI Script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: rust
 env:
-  global:
-    - secure: fetkajXgb3y9uAsgbEgmtnxwgTaifFhSwOzSYXKOj8kYnmIzU2OcQCtKoa/8zDTH3hNC6Yvg4QKF0vEopY22UP8YG4ky+QbFwEu3WcLyIZm1D1wOTnXqenyGod662bTP7fZMzDMIOu3vuUXR4SpmNJl5+k7d22SvChj2bc6V2Ok=
+    global:
+        - secure: fetkajXgb3y9uAsgbEgmtnxwgTaifFhSwOzSYXKOj8kYnmIzU2OcQCtKoa/8zDTH3hNC6Yvg4QKF0vEopY22UP8YG4ky+QbFwEu3WcLyIZm1D1wOTnXqenyGod662bTP7fZMzDMIOu3vuUXR4SpmNJl5+k7d22SvChj2bc6V2Ok=
+        - LD_LIBRARY_PATH: /usr/local/lib
 os:
     - linux
     - osx
-env:
-    global:
-        - LD_LIBRARY_PATH: /usr/local/lib
 before_script:
     - rustc -v
     - cargo -V
@@ -15,5 +13,5 @@ script:
     - cargo build -v
     - cargo test -v
     - cargo doc -v
-after_script:
+after_success:
   - curl http://www.rust-ci.org/artifacts/put?t=$RUSTCI_TOKEN | sh


### PR DESCRIPTION
- The script has two `env:` sections. Combined them.
- Generate docs only after successful compilation (avoid broken documentation for broken code).
- Fix indentation
