### PR TITLE
Added sprite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ authors = [
 name = "piston"
 path = "./src/lib.rs"
 
+[dependencies.uuid]
+
+git = "https://github.com/rust-lang/uuid"
+
 [dependencies.vecmath]
 
 git = "https://github.com/PistonDevelopers/vecmath"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 
 extern crate time;
 extern crate sync;
+extern crate uuid;
 
 // Crates used to reexport.
 extern crate vecmath_lib = "vecmath";
@@ -46,8 +47,10 @@ pub use event_iterator::{
     UpdateArgs,
 };
 pub use fps_counter::FPSCounter;
+pub use sprite::Sprite;
 
 pub mod window;
 mod event_iterator;
 mod asset_store;
 mod fps_counter;
+mod sprite;

--- a/src/sprite.rs
+++ b/src/sprite.rs
@@ -1,0 +1,247 @@
+
+use std::rc::Rc;
+use std::collections::hashmap::HashMap;
+use uuid::Uuid;
+
+use graphics::*;
+use graphics::internal::{
+    Vec2d,
+    Rectangle,
+};
+use graphics::vecmath::Scalar;
+
+/// A sprite is a texture with some properties.
+pub struct Sprite<I: ImageSize> {
+    id: Uuid,
+
+    anchor: Vec2d,
+
+    position: Vec2d,
+    rotation: Scalar,
+    scale: Vec2d,
+
+    flip_x: bool,
+    flip_y: bool,
+
+    children: Vec<Sprite<I>>,
+    children_index: HashMap<Uuid, uint>,
+
+    texture: Rc<I>,
+}
+
+impl<I: ImageSize> Sprite<I> {
+    /// Crate sprite from a texture
+    pub fn from_texture(texture: Rc<I>) -> Sprite<I> {
+        Sprite {
+            id: Uuid::new_v4(),
+
+            anchor: [0.5, 0.5],
+
+            position: [0.0, 0.0],
+            rotation: 0.0,
+            scale: [1.0, 1.0],
+
+            flip_x: false,
+            flip_y: false,
+
+            texture: texture,
+
+            children: Vec::new(),
+            children_index: HashMap::new(),
+        }
+    }
+
+    /// Get the sprite's id
+    #[inline(always)]
+    pub fn id(&self) -> Uuid {
+        self.id
+    }
+
+    /// Get the sprite's anchor point
+    ///
+    /// The value is normalized. Default value is [0.5, 0.5] (the center of texture)
+    #[inline(always)]
+    pub fn anchor(&self) -> (Scalar, Scalar) {
+        (self.anchor[0], self.anchor[1])
+    }
+
+    /// Set the sprite's anchor point
+    #[inline(always)]
+    pub fn set_anchor(&mut self, x: Scalar, y: Scalar) {
+        self.anchor = [x, y];
+    }
+
+    /// Get the sprite's position
+    #[inline(always)]
+    pub fn position(&self) -> (Scalar, Scalar) {
+        (self.position[0], self.position[1])
+    }
+
+    /// Set the sprite's position
+    #[inline(always)]
+    pub fn set_position(&mut self, x: Scalar, y: Scalar) {
+        self.position = [x, y];
+    }
+
+    /// Get the sprite's rotation (in degree)
+    #[inline(always)]
+    pub fn rotation(&self) -> Scalar {
+        self.rotation
+    }
+
+    /// Set the sprite's rotation (in degree)
+    #[inline(always)]
+    pub fn set_rotation(&mut self, deg: Scalar) {
+        self.rotation = deg;
+    }
+
+    /// Whether or not the sprite is flipped horizontally.
+    ///
+    /// It only flips the texture of the sprite,
+    /// and not the texture of the sprite’s children.
+    ///
+    /// Also, flipping the texture doesn’t alter the `anchor`.
+    ///
+    /// If you want to flip the `anchor` too,
+    /// and/or to flip the children too use: sprite.scale.x *= -1;
+    #[inline(always)]
+    pub fn flip_x(&self) -> bool {
+        self.flip_x
+    }
+
+    /// Flip the sprite
+    #[inline(always)]
+    pub fn set_flip_x(&mut self, flip_x: bool) {
+        self.flip_x = flip_x;
+    }
+
+    /// Whether or not the sprite is flipped vertically.
+    ///
+    /// It only flips the texture of the sprite,
+    /// and not the texture of the sprite’s children.
+    ///
+    /// Also, flipping the texture doesn’t alter the `anchor`.
+    ///
+    /// If you want to flip the `anchor` too,
+    /// and/or to flip the children too use: sprite.scale.y *= -1;
+    #[inline(always)]
+    pub fn flip_y(&self) -> bool {
+        self.flip_y
+    }
+
+    /// Flip the sprite
+    #[inline(always)]
+    pub fn set_flip_y(&mut self, flip_y: bool) {
+        self.flip_y = flip_y;
+    }
+
+    /// Get the sprite's texture
+    #[inline(always)]
+    pub fn texture(&self) -> &Rc<I> {
+        &self.texture
+    }
+
+    /// Set the sprite's texture
+    #[inline(always)]
+    pub fn set_texture(&mut self, texture: Rc<I>) {
+        self.texture = texture;
+    }
+
+    /// Add a sprite as the child of this sprite, return the added sprite's id.
+    pub fn add_child(&mut self, sprite: Sprite<I>) -> Uuid {
+        let id = sprite.id();
+        self.children.push(sprite);
+        self.children_index.insert(id, self.children.len() - 1);
+        id
+    }
+
+    /// Find the child by `id` from this sprite's children or grandchild
+    pub fn child(&self, id: Uuid) -> Option<&Sprite<I>> {
+        match self.children_index.find(&id) {
+            Some(i) => { Some(&self.children[*i]) },
+            None => {
+                for child in self.children.iter() {
+                    match child.child(id) {
+                        Some(c) => {
+                            return Some(c);
+                        }
+                        _ => {}
+                    }
+                }
+
+                None
+            }
+        }
+    }
+
+    /// Find the child by `id` from this sprite's children or grandchild, mutability
+    pub fn child_mut(&mut self, id: Uuid) -> Option<&mut Sprite<I>> {
+        match self.children_index.find(&id) {
+            Some(i) => { Some(self.children.get_mut(*i)) },
+            None => {
+                for child in self.children.mut_iter() {
+                    match child.child_mut(id) {
+                        Some(c) => {
+                            return Some(c);
+                        }
+                        _ => {}
+                    }
+                }
+
+                None
+            }
+        }
+    }
+
+    /// Draw this sprite and it's children
+    pub fn draw<B: BackEnd<I>>(&self, c: &Context, b: &mut B) {
+        let (w, h) = self.texture.get_size();
+        let w = w as f64;
+        let h = h as f64;
+        let anchor = [self.anchor[0] * w, self.anchor[1] * h];
+
+        let transformed = c.trans(self.position[0], self.position[1])
+                           .rot_deg(self.rotation)
+                           .scale(self.scale[0], self.scale[1]);
+
+        let mut model = transformed.rect(-anchor[0],
+                                         -anchor[1],
+                                          w,
+                                          h);
+
+        if self.flip_x {
+            model = model.trans(w - 2.0 * anchor[0], 0.0).flip_h();
+        }
+
+        if self.flip_y {
+            model = model.trans(0.0, h - 2.0 * anchor[1]).flip_v();
+        }
+
+        // for debug: bounding_box
+        //model.rgb(1.0, 0.0, 0.0).draw(b);
+
+        model.image(&*self.texture).draw(b);
+
+        // for debug: anchor point
+        //c.trans(self.position[0], self.position[1]).rect(-5.0, -5.0, 10.0, 10.0).rgb(0.0, 0.0, 1.0).draw(b);
+
+        for child in self.children.iter() {
+            child.draw(&transformed, b);
+        }
+    }
+
+    /// Get the sprite's bounding box
+    pub fn bounding_box(&self) -> Rectangle {
+        let (w, h) = self.texture.get_size();
+        let w = w as f64 * self.scale[0];
+        let h = h as f64 * self.scale[1];
+
+        [
+            self.position[0] - self.anchor[0] * w,
+            self.position[1] - self.anchor[1] * h,
+            w,
+            h
+        ]
+    }
+}
+


### PR DESCRIPTION
The sprite is a texture with some drawing properties.
## Anchor Point

The anchor point is a point in normalized texture coordinate. It is referenced when transforming or rotating.
## Position

Where the anchor point is in the world coordinate.
## Rotation

The sprite can rotate around anchor point.
## Scale

The sprite can also scale along X/Y direction.
## Flip

The sprite can flip vertically or horizontally.
## Children

The sprite can have children. The child's position is relative to it's parent.

Once this PR is merged, I'll send a PR of an example with sprite into `piston-example`. You can see the usage in my [swing-copters-rs](https://github.com/Coeuvre/swing-copters-rs/blob/master/src/main.rs#L63).
