### PR TITLE
Use fork url in contributing guide instead of pointing to the button location

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ We use the issue tracker heavily. We try to plan as much as possible up front an
 
 Here is how you get started:
 
-1. Fork the repository (the button in the upper right corner).
+1. [Fork](https://github.com/PistonDevelopers/piston/fork) the repository.
 2. Clone your repository to the local hard drive ([GitHub for Mac](https://mac.github.com/), [Github for Window](https://windows.github.com/)).
 3. Open up the Terminal and navigate to the project directory.
 4. If you have not installed Rust yet, download it [here](http://www.rust-lang.org/).


### PR DESCRIPTION
GitHub actually has a pretty nice feature for contributing guides. If you append `/fork` to the URL of the repository, you get directly to a fork page, that asks you, with which account you want to fork it.
