### PR TITLE
Closes #908 - Fix urls in Cargo.toml for sub crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ authors = [
 keywords = ["piston", "game", "engine", "core"]
 description = "The Piston game engine core libraries"
 license = "MIT"
-repository = "https://github.com/pistondevelopers/piston.git"
-homepage = "https://github.com/pistondevelopers/piston"
+repository = "https://github.com/PistonDevelopers/piston.git"
+homepage = "https://github.com/PistonDevelopers/piston"
 
 [lib]
 

--- a/src/event/Cargo.toml
+++ b/src/event/Cargo.toml
@@ -10,8 +10,8 @@ keywords = ["event", "piston"]
 description = "A library for flexible generic event threading"
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/pistondevelopers/event.git"
-homepage = "https://github.com/pistondevelopers/event"
+repository = "https://github.com/PistonDevelopers/piston.git"
+homepage = "https://github.com/PistonDevelopers/piston"
 
 [lib]
 

--- a/src/event_loop/Cargo.toml
+++ b/src/event_loop/Cargo.toml
@@ -12,8 +12,8 @@ keywords = ["game", "event", "loop", "piston"]
 description = "A generic event loop for games and interactive applications"
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/pistondevelopers/event_loop.git"
-homepage = "https://github.com/pistondevelopers/event_loop"
+repository = "https://github.com/PistonDevelopers/piston.git"
+homepage = "https://github.com/PistonDevelopers/piston"
 
 [lib]
 

--- a/src/input/Cargo.toml
+++ b/src/input/Cargo.toml
@@ -7,8 +7,8 @@ keywords = ["keyboard", "mouse", "input", "piston"]
 description = "A structure for user input"
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/pistondevelopers/input.git"
-homepage = "https://github.com/pistondevelopers/input"
+repository = "https://github.com/PistonDevelopers/piston.git"
+homepage = "https://github.com/PistonDevelopers/piston"
 
 [lib]
 

--- a/src/window/Cargo.toml
+++ b/src/window/Cargo.toml
@@ -10,8 +10,8 @@ keywords = ["window", "game", "piston"]
 description = "A library for window abstraction"
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/pistondevelopers/window.git"
-homepage = "https://github.com/pistondevelopers/window"
+repository = "https://github.com/PistonDevelopers/piston.git"
+homepage = "https://github.com/PistonDevelopers/piston"
 
 [lib]
 name = "window"


### PR DESCRIPTION
- `repository` field in all `Cargo.toml` files changed to `https://github.com/PistonDevelopers/piston.git`.
- `homepage` field in all `Cargo.toml` files changed to `https://github.com/PistonDevelopers/piston`.