### PR TITLE
Closes #910 - Add crates.io version buttons to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Piston [![Build Status](https://travis-ci.org/PistonDevelopers/piston.svg)](https://travis-ci.org/PistonDevelopers/piston)
+# Piston [![Build Status](https://travis-ci.org/PistonDevelopers/piston.svg)](https://travis-ci.org/PistonDevelopers/piston)[![Crates.io](https://img.shields.io/crates/v/piston.svg?style=flat-square)](https://crates.io/crates/piston)
 
 A user friendly game engine written in Rust
 

--- a/src/event/README.md
+++ b/src/event/README.md
@@ -1,4 +1,4 @@
-# event [![Build Status](https://travis-ci.org/PistonDevelopers/event.svg?branch=master)](https://travis-ci.org/PistonDevelopers/event)
+# event [![Build Status](https://travis-ci.org/PistonDevelopers/piston.svg)](https://travis-ci.org/PistonDevelopers/piston)[![Crates.io](https://img.shields.io/crates/v/piston.svg?style=flat-square)](https://crates.io/crates/piston)
 
 A library for flexible generic event threading
 

--- a/src/event_loop/README.md
+++ b/src/event_loop/README.md
@@ -1,4 +1,4 @@
-event_loop [![Build Status](https://travis-ci.org/PistonDevelopers/event_loop.svg?branch=master)](https://travis-ci.org/PistonDevelopers/event_loop)
+event_loop [![Build Status](https://travis-ci.org/PistonDevelopers/piston.svg)](https://travis-ci.org/PistonDevelopers/piston)[![Crates.io](https://img.shields.io/crates/v/piston.svg?style=flat-square)](https://crates.io/crates/piston)
 ==========
 
 A generic event loop for games and interactive applications

--- a/src/input/README.md
+++ b/src/input/README.md
@@ -1,4 +1,4 @@
-# input [![Build Status](https://travis-ci.org/PistonDevelopers/input.svg?branch=master)](https://travis-ci.org/PistonDevelopers/input)
+# input [![Build Status](https://travis-ci.org/PistonDevelopers/piston.svg)](https://travis-ci.org/PistonDevelopers/piston)[![Crates.io](https://img.shields.io/crates/v/piston.svg?style=flat-square)](https://crates.io/crates/piston)
 
 A structure for user input.
 

--- a/src/window/README.md
+++ b/src/window/README.md
@@ -1,4 +1,4 @@
-window [![Build Status](https://travis-ci.org/PistonDevelopers/window.svg?branch=master)](https://travis-ci.org/PistonDevelopers/window)
+window [![Build Status](https://travis-ci.org/PistonDevelopers/piston.svg)](https://travis-ci.org/PistonDevelopers/piston)[![Crates.io](https://img.shields.io/crates/v/piston.svg?style=flat-square)](https://crates.io/crates/piston)
 ======
 
 A library for window abstraction


### PR DESCRIPTION
Added these buttons to all `README.md` files:
 [![Build Status](https://travis-ci.org/PistonDevelopers/piston.svg)](https://travis-ci.org/PistonDevelopers/piston)[![Crates.io](https://img.shields.io/crates/v/piston.svg?style=flat-square)](https://crates.io/crates/piston)