### PR TITLE
insert  inside derive of Struct Size from window

### DIFF
--- a/src/window/src/lib.rs
+++ b/src/window/src/lib.rs
@@ -14,7 +14,7 @@ use input::Input;
 pub type ProcAddress = *const libc::c_void;
 
 /// Size in pixels.
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Size {
     /// The width in pixels.
     pub width: u32,


### PR DESCRIPTION
Hello @bvssvni,

I recommand a usage of **struct Size** with **Debug** because it's can be helpfull in this context: https://github.com/gbersac/gomoku_42/blob/968cc8bda2f065f992a173663d1adf2e46caf059/src/display/mouse.rs#L6