### PR TITLE
Use `()` instead of `libc::void`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston"
-version = "0.15.1"
+version = "0.16.0"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",
@@ -33,8 +33,8 @@ version = "0.8.0"
 
 [dependencies.pistoncore-window]
 path = "src/window"
-version = "0.13.0"
+version = "0.14.0"
 
 [dependencies.pistoncore-event_loop]
 path = "src/event_loop"
-version = "0.15.0"
+version = "0.16.0"

--- a/src/event_loop/Cargo.toml
+++ b/src/event_loop/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "pistoncore-event_loop"
-version = "0.15.0"
+version = "0.16.0"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",
@@ -22,7 +22,7 @@ path = "src/lib.rs"
 
 [dependencies.pistoncore-window]
 path = "../window"
-version = "0.13.0"
+version = "0.14.0"
 
 [dependencies.pistoncore-input]
 path = "../input"

--- a/src/event_loop/src/lib.rs
+++ b/src/event_loop/src/lib.rs
@@ -3,14 +3,15 @@
 #![deny(missing_docs)]
 #![deny(missing_copy_implementations)]
 
-extern crate time;
 extern crate window;
 extern crate input;
 extern crate viewport;
+extern crate time;
 
 use std::cell::RefCell;
 use std::rc::Rc;
-use std::thread::sleep_ms;
+use std::thread::sleep;
+use std::time::Duration;
 use std::cmp;
 use std::marker::PhantomData;
 use window::Window;
@@ -170,8 +171,10 @@ pub struct WindowEvents<W, E>
 
 static BILLION: u64 = 1_000_000_000;
 
-fn ns_to_ms(ns: u64) -> u32 {
-    (ns / 1_000_000) as u32
+fn ns_to_duration(ns: u64) -> Duration {
+    let secs = ns / BILLION;
+    let nanos = (ns % BILLION) as u32;
+    Duration::new(secs, nanos)
 }
 
 /// The default updates per second.
@@ -303,7 +306,7 @@ impl<W, E> Iterator for WindowEvents<W, E>
                                 let seconds = ((next_event - current_time) as f64) / (BILLION as f64);
                                 return Some(EventMap::idle(IdleArgs { dt: seconds }))
                             }
-                            sleep_ms(ns_to_ms(next_event - current_time));
+                            sleep(ns_to_duration(next_event - current_time));
                             State::UpdateLoop(Idle::No)
                         } else if next_event == next_frame {
                             State::Render

--- a/src/window/Cargo.toml
+++ b/src/window/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "pistoncore-window"
-version = "0.13.0"
+version = "0.14.0"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>"
@@ -22,5 +22,4 @@ path = "../input"
 version = "0.8.0"
 
 [dependencies]
-libc = "0.2"
 shader_version = "0.2.1"

--- a/src/window/src/lib.rs
+++ b/src/window/src/lib.rs
@@ -3,7 +3,6 @@
 
 //! Window abstraction
 
-extern crate libc;
 extern crate input;
 extern crate shader_version;
 
@@ -11,7 +10,7 @@ use shader_version::OpenGL;
 use input::Input;
 
 /// The type of an OpenGL function address.
-pub type ProcAddress = *const libc::c_void;
+pub type ProcAddress = *const ();
 
 /// Size in pixels.
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/piston/issues/1000

- Removed dependency on libc in pistoncore-window
- Updated from `sleep_ms` to `sleep` in pistoncore-event_loop
- Bumped to 0.16.0