### PR TITLE
While let

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston"
-version = "0.16.0"
+version = "0.17.0"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",
@@ -37,4 +37,4 @@ version = "0.14.0"
 
 [dependencies.pistoncore-event_loop]
 path = "src/event_loop"
-version = "0.16.0"
+version = "0.17.0"

--- a/src/event_loop/Cargo.toml
+++ b/src/event_loop/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "pistoncore-event_loop"
-version = "0.16.0"
+version = "0.17.0"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",

--- a/src/event_loop/src/lib.rs
+++ b/src/event_loop/src/lib.rs
@@ -8,36 +8,21 @@ extern crate input;
 extern crate viewport;
 extern crate time;
 
-use std::cell::RefCell;
-use std::rc::Rc;
 use std::thread::sleep;
 use std::time::Duration;
 use std::cmp;
-use std::marker::PhantomData;
 use window::Window;
 use input::{ AfterRenderArgs, Event, IdleArgs, RenderArgs, UpdateArgs };
 
 /// A trait for create event iterator from window.
-pub trait Events<W> where W: Window {
+pub trait Events {
     /// Creates event iterator from window.
-    fn events(self) -> WindowEvents<W, Event<W::Event>>;
+    fn events(&self) -> WindowEvents;
 }
 
-impl<W> Events<W> for Rc<RefCell<W>> where W: Window {
-    fn events(self) -> WindowEvents<W, Event<W::Event>> {
-        WindowEvents::new(self)
-    }
-}
-
-impl<W> Events<W> for W where W: Window {
-    fn events(self) -> WindowEvents<W, Event<W::Event>> {
-        Rc::new(RefCell::new(self)).events()
-    }
-}
-
-impl<'a, W> Events<W> for &'a Rc<RefCell<W>> where W: Window {
-    fn events(self) -> WindowEvents<W, Event<W::Event>> {
-        self.clone().events()
+impl<W> Events for W where W: Window {
+    fn events(&self) -> WindowEvents {
+        WindowEvents::new()
     }
 }
 
@@ -120,10 +105,8 @@ pub trait EventLoop: Sized {
 /// *Warning: Because the iterator polls events from the window back-end,
 /// it must be used on the same thread as the window back-end (usually main thread),
 /// unless the window back-end supports multi-thread event polling.*
-pub struct WindowEvents<W, E>
-    where W: Window
-{
-    window: Rc<RefCell<W>>,
+#[derive(Copy, Clone)]
+pub struct WindowEvents {
     state: State,
     last_update: u64,
     last_frame: u64,
@@ -132,7 +115,6 @@ pub struct WindowEvents<W, E>
     dt: f64,
     swap_buffers: bool,
     bench_mode: bool,
-    _marker_e: PhantomData<E>,
 }
 
 static BILLION: u64 = 1_000_000_000;
@@ -148,16 +130,14 @@ pub const DEFAULT_UPS: u64 = 120;
 /// The default maximum frames per second.
 pub const DEFAULT_MAX_FPS: u64 = 60;
 
-impl<W> WindowEvents<W, Event<<W as Window>::Event>>
-    where W: Window
+impl WindowEvents
 {
     /// Creates a new event iterator with default UPS and FPS settings.
-    pub fn new(window: Rc<RefCell<W>>) -> WindowEvents<W, Event<<W as Window>::Event>> {
+    pub fn new() -> WindowEvents {
         let start = time::precise_time_ns();
         let updates_per_second = DEFAULT_UPS;
         let max_frames_per_second = DEFAULT_MAX_FPS;
         WindowEvents {
-            window: window,
             state: State::Render,
             last_update: start,
             last_frame: start,
@@ -166,43 +146,16 @@ impl<W> WindowEvents<W, Event<<W as Window>::Event>>
             dt: 1.0 / updates_per_second as f64,
             swap_buffers: true,
             bench_mode: false,
-            _marker_e: PhantomData,
         }
     }
-}
-
-impl<W> EventLoop for WindowEvents<W, Event<<W as Window>::Event>>
-    where W: Window
-{
-    fn set_ups(&mut self, frames: u64) {
-        self.dt_update_in_ns = BILLION / frames;
-        self.dt = 1.0 / frames as f64;
-    }
-
-    fn set_max_fps(&mut self, frames: u64) {
-        self.dt_frame_in_ns = BILLION / frames;
-    }
-
-    fn set_swap_buffers(&mut self, enable: bool) {
-        self.swap_buffers = enable;
-    }
-
-    fn set_bench_mode(&mut self, enable: bool) {
-        self.bench_mode = enable;
-    }
-}
-
-impl<W> Iterator for WindowEvents<W, Event<<W as Window>::Event>>
-    where W: Window
-{
-    type Item = Event<<W as Window>::Event>;
 
     /// Returns the next game event.
-    fn next(&mut self) -> Option<Event<<W as Window>::Event>> {
+    pub fn next<W>(&mut self, window: &mut W) -> Option<Event<W::Event>>
+        where W: Window
+    {
         loop {
             self.state = match self.state {
                 State::Render => {
-                    let window = self.window.borrow();
                     if window.should_close() { return None; }
 
                     if self.bench_mode {
@@ -233,7 +186,7 @@ impl<W> Iterator for WindowEvents<W, Event<<W as Window>::Event>>
                 }
                 State::SwapBuffers => {
                     if self.swap_buffers {
-                        self.window.borrow_mut().swap_buffers();
+                        window.swap_buffers();
                         self.state = State::UpdateLoop(Idle::No);
                         return Some(Event::AfterRender(AfterRenderArgs));
                     } else {
@@ -258,7 +211,7 @@ impl<W> Iterator for WindowEvents<W, Event<<W as Window>::Event>>
                         let next_update = self.last_update + self.dt_update_in_ns;
                         let next_event = cmp::min(next_frame, next_update);
                         if next_event > current_time {
-                            if let Some(x) = self.window.borrow_mut().poll_event() {
+                            if let Some(x) = window.poll_event() {
                                 *idle = Idle::No;
                                 return Some(Event::Input(x));
                             } else if *idle == Idle::No {
@@ -278,13 +231,13 @@ impl<W> Iterator for WindowEvents<W, Event<<W as Window>::Event>>
                 State::HandleEvents => {
                     if self.bench_mode {
                         // Ignore input to prevent it affecting the benchmark.
-                        match self.window.borrow_mut().poll_event() {
+                        match window.poll_event() {
                             None => State::Update,
                             Some(_) => State::HandleEvents,
                         }
                     } else {
                         // Handle all events before updating.
-                        match self.window.borrow_mut().poll_event() {
+                        match window.poll_event() {
                             None => State::Update,
                             Some(x) => { return Some(Event::Input(x)); },
                         }
@@ -297,5 +250,24 @@ impl<W> Iterator for WindowEvents<W, Event<<W as Window>::Event>>
                 }
             };
         }
+    }
+}
+
+impl EventLoop for WindowEvents {
+    fn set_ups(&mut self, frames: u64) {
+        self.dt_update_in_ns = BILLION / frames;
+        self.dt = 1.0 / frames as f64;
+    }
+
+    fn set_max_fps(&mut self, frames: u64) {
+        self.dt_frame_in_ns = BILLION / frames;
+    }
+
+    fn set_swap_buffers(&mut self, enable: bool) {
+        self.swap_buffers = enable;
+    }
+
+    fn set_bench_mode(&mut self, enable: bool) {
+        self.bench_mode = enable;
     }
 }


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/piston/issues/1027

This is a breaking change.

- Bumped to 0.17.0
- Iterator replaced by `WindowEvent::next(&mut self, &mut window)`

This change mostly affects code that depends directly on the "piston" or "pistoncore-event_loop" crate. The "piston_window" crate will keep the Iterator design for now.

To fix your code, do the following:

```Rust
// Add a `mut` to make the window mutable.
let mut window: GlutinWindow = WindowSettings::new("title", [width, height])
    .build().unwrap();

// Create an object to track events.
let mut events = window.events();
// Pass in a mutable reference to the window, using a `while let`.
while let Some(e) = events.next(&mut window) {
    ...
}
```

By using a `while let` instead of a `for`, we do not have to move the window into an `Rc<RefCell<T>>`. It also makes it easier to pass around the `WindowEvents` object for different game loops in separate functions.