### PR TITLE
Implement From<T> for event enum types where conversions from T to variants are unambiguous

### DIFF
--- a/src/input/src/event.rs
+++ b/src/input/src/event.rs
@@ -20,3 +20,33 @@ pub enum Event<I = Input> {
     /// Input event.
     Input(I),
 }
+
+impl<I> From<RenderArgs> for Event<I> {
+    fn from(args: RenderArgs) -> Self {
+        Event::Render(args)
+    }
+}
+
+impl<I> From<AfterRenderArgs> for Event<I> {
+    fn from(args: AfterRenderArgs) -> Self {
+        Event::AfterRender(args)
+    }
+}
+
+impl<I> From<UpdateArgs> for Event<I> {
+    fn from(args: UpdateArgs) -> Self {
+        Event::Update(args)
+    }
+}
+
+impl<I> From<IdleArgs> for Event<I> {
+    fn from(args: IdleArgs) -> Self {
+        Event::Idle(args)
+    }
+}
+
+impl From<Input> for Event<Input> {
+    fn from(input: Input) -> Self {
+        Event::Input(input)
+    }
+}

--- a/src/input/src/lib.rs
+++ b/src/input/src/lib.rs
@@ -107,3 +107,33 @@ pub enum Input {
     /// Window gained or lost cursor.
     Cursor(bool),
 }
+
+impl From<Key> for Button {
+    fn from(key: Key) -> Self {
+        Button::Keyboard(key)
+    }
+}
+
+impl From<MouseButton> for Button {
+    fn from(btn: MouseButton) -> Self {
+        Button::Mouse(btn)
+    }
+}
+
+impl From<JoystickButton> for Button {
+    fn from(btn: JoystickButton) -> Self {
+        Button::Joystick(btn)
+    }
+}
+
+impl From<JoystickAxisArgs> for Motion {
+    fn from(args: JoystickAxisArgs) -> Self {
+        Motion::JoystickAxis(args)
+    }
+}
+
+impl From<Motion> for Input {
+    fn from(motion: Motion) -> Self {
+        Input::Move(motion)
+    }
+}


### PR DESCRIPTION
I came across a use case for this in conrod, it should save the need to import the event enum types in some cases :+1:

I don't think this is a breaking change.