### PR TITLE
Fix error in rebase

### DIFF
--- a/src/window/src/lib.rs
+++ b/src/window/src/lib.rs
@@ -110,7 +110,7 @@ pub trait BuildFromWindowSettings: Sized {
     ///
     /// See your backend's documentation for details about what kind of
     /// error strings can be returned, and the conditions for error.
-    fn build_from_window_settings(settings: WindowSettings)
+    fn build_from_window_settings(settings: &WindowSettings)
     -> Result<Self, String>;
 }
 
@@ -345,7 +345,7 @@ impl WindowSettings {
     /// This function will return an error if your backend returns an error.
     /// See your backend's documentation on `build_from_window_settings()`
     /// for more details.
-    pub fn build<W: BuildFromWindowSettings>(self) -> Result<W, String> {
+    pub fn build<W: BuildFromWindowSettings>(&self) -> Result<W, String> {
         BuildFromWindowSettings::build_from_window_settings(self)
     }
 

--- a/src/window/src/no_window.rs
+++ b/src/window/src/no_window.rs
@@ -34,11 +34,11 @@ pub struct NoWindow {
 
 impl NoWindow {
 	/// Creates a new `NoWindow`.
-    pub fn new(settings: WindowSettings) -> NoWindow {
+    pub fn new(settings: &WindowSettings) -> NoWindow {
         NoWindow {
             should_close: false,
-            title: settings.title,
-            size: settings.size,
+            title: settings.get_title(),
+            size: settings.get_size(),
 			pos: Position { x: 0, y: 0 }
         }
     }
@@ -64,8 +64,7 @@ impl BuildFromWindowSettings for NoWindow {
 	/// # Errors
 	///
 	/// This function will always return without error.
-    fn build_from_window_settings(settings: WindowSettings)
-    -> Result<Self, String> {
+    fn build_from_window_settings(settings: &WindowSettings) -> Result<Self, String> {
         Ok(NoWindow::new(settings))
     }
 }


### PR DESCRIPTION
Fixed error in
https://github.com/PistonDevelopers/piston/commit/555285cfe4b8ab6bade60d
de5ffca3644baa829f that undid the change to `&WindowSettings`.