### PR TITLE
Release v0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston"
-version = "0.22.1"
+version = "0.23.0"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",
@@ -33,8 +33,8 @@ version = "0.12.0"
 
 [dependencies.pistoncore-window]
 path = "src/window"
-version = "0.19.0"
+version = "0.20.0"
 
 [dependencies.pistoncore-event_loop]
 path = "src/event_loop"
-version = "0.22.1"
+version = "0.23.0"

--- a/src/event_loop/Cargo.toml
+++ b/src/event_loop/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "pistoncore-event_loop"
-version = "0.22.1"
+version = "0.23.0"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",
@@ -22,7 +22,7 @@ path = "src/lib.rs"
 
 [dependencies.pistoncore-window]
 path = "../window"
-version = "0.19.0"
+version = "0.20.0"
 
 [dependencies.pistoncore-input]
 path = "../input"

--- a/src/window/Cargo.toml
+++ b/src/window/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "pistoncore-window"
-version = "0.19.0"
+version = "0.20.0"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>"


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/piston/milestones/v0.23

This release makes it easier to create and hide multiple windows within
the same application without using the underlying window API. Some extra fields were added
to `WindowSettings`, and the docs for pistoncore-window was improved.

- Changed `BuildFromWindowSettings::build_from_window_settings` to take
`&WindowSettings` instead of `WindowSettings`
- Derive `Clone` on `WindowSettings`
- Added missing methods on `WindowSettings`
- Added "resizable", "decorated" and "controllers" to `WindowSettings`
- Improved docs for pistoncore-window
- Handle input before rendering in event loop to fix panic when closing
window
- Added "position", "show" and "hide" to `AdvancedWindow`