### PR TITLE
Optimized standard events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston"
-version = "0.24.0"
+version = "0.25.0"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",
@@ -30,12 +30,12 @@ path = "./src/lib.rs"
 
 [dependencies.pistoncore-input]
 path = "src/input"
-version = "0.13.0"
+version = "0.14.0"
 
 [dependencies.pistoncore-window]
 path = "src/window"
-version = "0.21.0"
+version = "0.22.0"
 
 [dependencies.pistoncore-event_loop]
 path = "src/event_loop"
-version = "0.24.0"
+version = "0.25.0"

--- a/src/event_loop/Cargo.toml
+++ b/src/event_loop/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "pistoncore-event_loop"
-version = "0.24.0"
+version = "0.25.0"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",
@@ -22,11 +22,11 @@ path = "src/lib.rs"
 
 [dependencies.pistoncore-window]
 path = "../window"
-version = "0.21.0"
+version = "0.22.0"
 
 [dependencies.pistoncore-input]
 path = "../input"
-version = "0.13.0"
+version = "0.14.0"
 
 [dependencies]
 time = "0.1.33"

--- a/src/input/Cargo.toml
+++ b/src/input/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pistoncore-input"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["keyboard", "mouse", "input", "piston"]
 description = "A structure for user input"

--- a/src/input/benches/controller_axis.rs
+++ b/src/input/benches/controller_axis.rs
@@ -1,0 +1,39 @@
+#![feature(test)]
+
+extern crate test;
+extern crate input;
+
+use test::Bencher;
+use input::{ Event, ControllerAxisArgs, ControllerAxisEvent, Input, Motion };
+
+#[bench]
+fn bench_input_controller_axis(bencher: &mut Bencher) {
+    let e = Input::Move(Motion::ControllerAxis(ControllerAxisArgs {
+        id: 0,
+        axis: 0,
+        position: 0.0,
+    }));
+    bencher.iter(|| {
+        let _: Option<Input> = ControllerAxisEvent::from_controller_axis_args(ControllerAxisArgs {
+            id: 0,
+            axis: 0,
+            position: 1.0,
+        }, &e);
+    });
+}
+
+#[bench]
+fn bench_event_controller_axis(bencher: &mut Bencher) {
+    let e = Event::Input(Input::Move(Motion::ControllerAxis(ControllerAxisArgs {
+        id: 0,
+        axis: 0,
+        position: 0.0,
+    })));
+    bencher.iter(|| {
+        let _: Option<Event> = ControllerAxisEvent::from_controller_axis_args(ControllerAxisArgs {
+            id: 0,
+            axis: 0,
+            position: 1.0,
+        }, &e);
+    });
+}

--- a/src/input/benches/cursor.rs
+++ b/src/input/benches/cursor.rs
@@ -1,0 +1,23 @@
+#![feature(test)]
+
+extern crate test;
+extern crate input;
+
+use test::Bencher;
+use input::{ Event, CursorEvent, Input };
+
+#[bench]
+fn bench_input_cursor(bencher: &mut Bencher) {
+    let e = Input::Cursor(false);
+    bencher.iter(|| {
+        let _: Option<Input> = CursorEvent::from_cursor(true, &e);
+    });
+}
+
+#[bench]
+fn bench_event_cursor(bencher: &mut Bencher) {
+    let e = Event::Input(Input::Cursor(false));
+    bencher.iter(|| {
+        let _: Option<Event> = CursorEvent::from_cursor(true, &e);
+    });
+}

--- a/src/input/src/after_render.rs
+++ b/src/input/src/after_render.rs
@@ -1,7 +1,5 @@
-use std::any::Any;
-
-use GenericEvent;
-use AFTER_RENDER;
+use Event;
+use Input;
 
 /// After render arguments.
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -20,6 +18,7 @@ pub trait AfterRenderEvent: Sized {
     }
 }
 
+/* TODO: Enable when specialization gets stable.
 impl<T: GenericEvent> AfterRenderEvent for T {
     fn from_after_render_args(args: &AfterRenderArgs, old_event: &T) -> Option<Self> {
         GenericEvent::from_args(AFTER_RENDER, args as &Any, old_event)
@@ -38,6 +37,34 @@ impl<T: GenericEvent> AfterRenderEvent for T {
                 panic!("Expected AfterRenderArgs")
             }
         })
+    }
+}
+*/
+
+impl AfterRenderEvent for Input {
+    fn from_after_render_args(_args: &AfterRenderArgs, _old_event: &Input) -> Option<Self> {
+        None
+    }
+
+    fn after_render<U, F>(&self, mut _f: F) -> Option<U>
+        where F: FnMut(&AfterRenderArgs) -> U
+    {
+        None
+    }
+}
+
+impl<I> AfterRenderEvent for Event<I> {
+    fn from_after_render_args(args: &AfterRenderArgs, _old_event: &Event<I>) -> Option<Self> {
+        Some(Event::AfterRender(*args))
+    }
+
+    fn after_render<U, F>(&self, mut f: F) -> Option<U>
+        where F: FnMut(&AfterRenderArgs) -> U
+    {
+        match *self {
+            Event::AfterRender(ref args) => Some(f(args)),
+            _ => None
+        }
     }
 }
 

--- a/src/input/src/cursor.rs
+++ b/src/input/src/cursor.rs
@@ -1,6 +1,6 @@
 use std::any::Any;
 
-use { GenericEvent, CURSOR };
+use { Event, GenericEvent, Input, CURSOR };
 
 /// When window gets or loses cursor
 pub trait CursorEvent: Sized {
@@ -15,7 +15,46 @@ pub trait CursorEvent: Sized {
     }
 }
 
+/* TODO: Enable when specialization gets stable.
 impl<T: GenericEvent> CursorEvent for T {
+    fn from_cursor(cursor: bool, old_event: &Self) -> Option<Self> {
+        GenericEvent::from_args(CURSOR, &cursor as &Any, old_event)
+    }
+
+    fn cursor<U, F>(&self, mut f: F) -> Option<U>
+        where F: FnMut(bool) -> U
+    {
+        if self.event_id() != CURSOR {
+            return None;
+        }
+        self.with_args(|any| {
+            if let Some(&cursor) = any.downcast_ref::<bool>() {
+                Some(f(cursor))
+            } else {
+                panic!("Expected bool")
+            }
+        })
+    }
+}
+*/
+
+impl CursorEvent for Input {
+    fn from_cursor(cursor: bool, _old_event: &Self) -> Option<Self> {
+        Some(Input::Cursor(cursor))
+    }
+
+    fn cursor<U, F>(&self, mut f: F) -> Option<U>
+        where F: FnMut(bool) -> U
+    {
+        match *self {
+            Input::Cursor(val) => Some(f(val)),
+            _ => None
+        }
+    }
+}
+
+// TODO: Add impl for `Event<Input>` when specialization gets stable.
+impl<I: GenericEvent> CursorEvent for Event<I> {
     fn from_cursor(cursor: bool, old_event: &Self) -> Option<Self> {
         GenericEvent::from_args(CURSOR, &cursor as &Any, old_event)
     }

--- a/src/input/src/focus.rs
+++ b/src/input/src/focus.rs
@@ -1,6 +1,6 @@
 use std::any::Any;
 
-use { GenericEvent, FOCUS };
+use { Event, GenericEvent, Input, FOCUS };
 
 /// When window gets or loses focus
 pub trait FocusEvent: Sized {
@@ -15,7 +15,46 @@ pub trait FocusEvent: Sized {
     }
 }
 
+/* TODO: Enable when specialization gets stable.
 impl<T: GenericEvent> FocusEvent for T {
+    fn from_focused(focused: bool, old_event: &Self) -> Option<Self> {
+        GenericEvent::from_args(FOCUS, &focused as &Any, old_event)
+    }
+
+    fn focus<U, F>(&self, mut f: F) -> Option<U>
+        where F: FnMut(bool) -> U
+    {
+        if self.event_id() != FOCUS {
+            return None;
+        }
+        self.with_args(|any| {
+            if let Some(&focused) = any.downcast_ref::<bool>() {
+                Some(f(focused))
+            } else {
+                panic!("Expected bool")
+            }
+        })
+    }
+}
+*/
+
+impl FocusEvent for Input {
+    fn from_focused(focused: bool, _old_event: &Self) -> Option<Self> {
+        Some(Input::Focus(focused))
+    }
+
+    fn focus<U, F>(&self, mut f: F) -> Option<U>
+        where F: FnMut(bool) -> U
+    {
+        match *self {
+            Input::Focus(focused) => Some(f(focused)),
+            _ => None
+        }
+    }
+}
+
+// TODO: Add impl for `Event<Input>` when specialization gets stable.
+impl<I: GenericEvent> FocusEvent for Event<I> {
     fn from_focused(focused: bool, old_event: &Self) -> Option<Self> {
         GenericEvent::from_args(FOCUS, &focused as &Any, old_event)
     }

--- a/src/input/src/generic_event.rs
+++ b/src/input/src/generic_event.rs
@@ -3,6 +3,9 @@
 use std::borrow::ToOwned;
 use std::any::Any;
 
+use {AfterRenderEvent, CursorEvent, FocusEvent, IdleEvent,
+     PressEvent, ReleaseEvent, RenderEvent, ResizeEvent,
+     TextEvent, TouchEvent, UpdateEvent};
 use {AfterRenderArgs, ControllerAxisArgs, Button, Event, EventId, IdleArgs, Input,
      Motion, RenderArgs, TouchArgs, UpdateArgs};
 use {AFTER_RENDER, CONTROLLER_AXIS, CURSOR, FOCUS, IDLE, MOUSE_CURSOR,
@@ -10,7 +13,10 @@ use {AFTER_RENDER, CONTROLLER_AXIS, CURSOR, FOCUS, IDLE, MOUSE_CURSOR,
      TEXT, TOUCH, UPDATE};
 
 /// Implemented by all events
-pub trait GenericEvent: Sized {
+pub trait GenericEvent: Sized +
+    AfterRenderEvent + CursorEvent + FocusEvent + IdleEvent +
+    PressEvent + ReleaseEvent + RenderEvent + ResizeEvent +
+    TextEvent + TouchEvent + UpdateEvent {
     /// The id of this event.
     fn event_id(&self) -> EventId;
     /// Calls closure with arguments

--- a/src/input/src/generic_event.rs
+++ b/src/input/src/generic_event.rs
@@ -3,7 +3,7 @@
 use std::borrow::ToOwned;
 use std::any::Any;
 
-use {AfterRenderEvent, CursorEvent, FocusEvent, IdleEvent,
+use {AfterRenderEvent, ControllerAxisEvent, CursorEvent, FocusEvent, IdleEvent,
      MouseCursorEvent, MouseRelativeEvent, MouseScrollEvent,
      PressEvent, ReleaseEvent, RenderEvent, ResizeEvent,
      TextEvent, TouchEvent, UpdateEvent};
@@ -15,7 +15,7 @@ use {AFTER_RENDER, CONTROLLER_AXIS, CURSOR, FOCUS, IDLE, MOUSE_CURSOR,
 
 /// Implemented by all events
 pub trait GenericEvent: Sized +
-    AfterRenderEvent + CursorEvent + FocusEvent + IdleEvent +
+    AfterRenderEvent + ControllerAxisEvent + CursorEvent + FocusEvent + IdleEvent +
     MouseCursorEvent + MouseRelativeEvent + MouseScrollEvent +
     PressEvent + ReleaseEvent + RenderEvent + ResizeEvent +
     TextEvent + TouchEvent + UpdateEvent {
@@ -25,7 +25,9 @@ pub trait GenericEvent: Sized +
     fn with_args<'a, F, U>(&'a self, f: F) -> U
         where F: FnMut(&Any) -> U
     ;
-    /// Converts from arguments to `Self`
+    /// Converts from arguments to `Self`.
+    ///
+    /// Returns `None` if old event is not same kind.
     fn from_args(event_id: EventId, any: &Any, old_event: &Self) -> Option<Self>;
 }
 

--- a/src/input/src/generic_event.rs
+++ b/src/input/src/generic_event.rs
@@ -4,6 +4,7 @@ use std::borrow::ToOwned;
 use std::any::Any;
 
 use {AfterRenderEvent, CursorEvent, FocusEvent, IdleEvent,
+     MouseCursorEvent, MouseRelativeEvent, MouseScrollEvent,
      PressEvent, ReleaseEvent, RenderEvent, ResizeEvent,
      TextEvent, TouchEvent, UpdateEvent};
 use {AfterRenderArgs, ControllerAxisArgs, Button, Event, EventId, IdleArgs, Input,
@@ -15,6 +16,7 @@ use {AFTER_RENDER, CONTROLLER_AXIS, CURSOR, FOCUS, IDLE, MOUSE_CURSOR,
 /// Implemented by all events
 pub trait GenericEvent: Sized +
     AfterRenderEvent + CursorEvent + FocusEvent + IdleEvent +
+    MouseCursorEvent + MouseRelativeEvent + MouseScrollEvent +
     PressEvent + ReleaseEvent + RenderEvent + ResizeEvent +
     TextEvent + TouchEvent + UpdateEvent {
     /// The id of this event.

--- a/src/input/src/idle.rs
+++ b/src/input/src/idle.rs
@@ -1,6 +1,4 @@
-use std::any::Any;
-
-use { GenericEvent, IDLE };
+use { Event, Input };
 
 /// Idle arguments, such as expected idle time in seconds.
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -26,6 +24,7 @@ pub trait IdleEvent: Sized {
     }
 }
 
+/* TODO: Enable when specialization gets stable.
 impl<T> IdleEvent for T where T: GenericEvent {
     fn from_idle_args(args: &IdleArgs, old_event: &Self) -> Option<Self> {
         GenericEvent::from_args(IDLE, args as &Any, old_event)
@@ -44,6 +43,34 @@ impl<T> IdleEvent for T where T: GenericEvent {
                 panic!("Expected IdleArgs")
             }
         })
+    }
+}
+*/
+
+impl IdleEvent for Input {
+    fn from_idle_args(_args: &IdleArgs, _old_event: &Self) -> Option<Self> {
+        None
+    }
+
+    fn idle<U, F>(&self, mut _f: F) -> Option<U>
+        where F: FnMut(&IdleArgs) -> U
+    {
+        None
+    }
+}
+
+impl<I> IdleEvent for Event<I> {
+    fn from_idle_args(args: &IdleArgs, _old_event: &Self) -> Option<Self> {
+        Some(Event::Idle(*args))
+    }
+
+    fn idle<U, F>(&self, mut f: F) -> Option<U>
+        where F: FnMut(&IdleArgs) -> U
+    {
+        match *self {
+            Event::Idle(ref args) => Some(f(args)),
+            _ => None
+        }
     }
 }
 

--- a/src/input/src/keyboard.rs
+++ b/src/input/src/keyboard.rs
@@ -64,8 +64,6 @@ impl ModifierKey {
     ///
     /// If the left or side button is released, it counts as a release.
     pub fn event<E: GenericEvent>(&mut self, e: &E) {
-        use { FocusEvent, PressEvent, ReleaseEvent };
-
         if let Some(button) = e.press_args() {
             match button {
                 Button::Keyboard(Key::LCtrl) |

--- a/src/input/src/mouse.rs
+++ b/src/input/src/mouse.rs
@@ -3,7 +3,7 @@
 
 use std::any::Any;
 
-use { GenericEvent, MOUSE_SCROLL, MOUSE_RELATIVE, MOUSE_CURSOR };
+use { Event, GenericEvent, Input, Motion, MOUSE_SCROLL, MOUSE_RELATIVE, MOUSE_CURSOR };
 
 /// Represent a mouse button.
 #[derive(Copy, Clone, RustcDecodable, RustcEncodable, PartialEq,
@@ -89,7 +89,46 @@ pub trait MouseCursorEvent: Sized {
     }
 }
 
+/* TODO: Enable when specialization gets stable.
 impl<T: GenericEvent> MouseCursorEvent for T {
+    fn from_xy(x: f64, y: f64, old_event: &Self) -> Option<Self> {
+        GenericEvent::from_args(MOUSE_CURSOR, &(x, y) as &Any, old_event)
+    }
+
+    fn mouse_cursor<U, F>(&self, mut f: F) -> Option<U>
+        where F: FnMut(f64, f64) -> U
+    {
+        if self.event_id() != MOUSE_CURSOR {
+            return None;
+        }
+        self.with_args(|any| {
+            if let Some(&(x, y)) = any.downcast_ref::<(f64, f64)>() {
+                Some(f(x, y))
+            } else {
+                panic!("Expected (f64, f64)")
+            }
+        })
+    }
+}
+*/
+
+impl MouseCursorEvent for Input {
+    fn from_xy(x: f64, y: f64, _old_event: &Self) -> Option<Self> {
+        Some(Input::Move(Motion::MouseCursor(x, y)))
+    }
+
+    fn mouse_cursor<U, F>(&self, mut f: F) -> Option<U>
+        where F: FnMut(f64, f64) -> U
+    {
+        match *self {
+            Input::Move(Motion::MouseCursor(x, y)) => Some(f(x, y)),
+            _ => None
+        }
+    }
+}
+
+// TODO: Add impl for `Event<Input>` when specialization gets stable.
+impl<I: GenericEvent> MouseCursorEvent for Event<I> {
     fn from_xy(x: f64, y: f64, old_event: &Self) -> Option<Self> {
         GenericEvent::from_args(MOUSE_CURSOR, &(x, y) as &Any, old_event)
     }
@@ -123,7 +162,46 @@ pub trait MouseRelativeEvent: Sized {
     }
 }
 
+/* TODO: Enable when specialization gets stable.
 impl<T: GenericEvent> MouseRelativeEvent for T {
+    fn from_xy(x: f64, y: f64, old_event: &Self) -> Option<Self> {
+        GenericEvent::from_args(MOUSE_RELATIVE, &(x, y) as &Any, old_event)
+    }
+
+    fn mouse_relative<U, F>(&self, mut f: F) -> Option<U>
+        where F: FnMut(f64, f64) -> U
+    {
+        if self.event_id() != MOUSE_RELATIVE {
+            return None;
+        }
+        self.with_args(|any| {
+            if let Some(&(x, y)) = any.downcast_ref::<(f64, f64)>() {
+                Some(f(x, y))
+            } else {
+                panic!("Expected (f64, f64)")
+            }
+        })
+    }
+}
+*/
+
+impl MouseRelativeEvent for Input {
+    fn from_xy(x: f64, y: f64, _old_event: &Self) -> Option<Self> {
+        Some(Input::Move(Motion::MouseRelative(x, y)))
+    }
+
+    fn mouse_relative<U, F>(&self, mut f: F) -> Option<U>
+        where F: FnMut(f64, f64) -> U
+    {
+        match *self {
+            Input::Move(Motion::MouseRelative(x, y)) => Some(f(x, y)),
+            _ => None
+        }
+    }
+}
+
+// TODO: Add impl for `Event<Input>` when specialization gets stable.
+impl<I: GenericEvent> MouseRelativeEvent for Event<I> {
     fn from_xy(x: f64, y: f64, old_event: &Self) -> Option<Self> {
         GenericEvent::from_args(MOUSE_RELATIVE, &(x, y) as &Any, old_event)
     }
@@ -157,7 +235,46 @@ pub trait MouseScrollEvent: Sized {
     }
 }
 
+/* TODO: Enable when specialization gets stable.
 impl<T: GenericEvent> MouseScrollEvent for T {
+    fn from_xy(x: f64, y: f64, old_event: &Self) -> Option<Self> {
+        GenericEvent::from_args(MOUSE_SCROLL, &(x, y) as &Any, old_event)
+    }
+
+    fn mouse_scroll<U, F>(&self, mut f: F) -> Option<U>
+        where F: FnMut(f64, f64) -> U
+    {
+        if self.event_id() != MOUSE_SCROLL {
+            return None;
+        }
+        self.with_args(|any| {
+            if let Some(&(x, y)) = any.downcast_ref::<(f64, f64)>() {
+                Some(f(x, y))
+            } else {
+                panic!("Expected (f64, f64)")
+            }
+        })
+    }
+}
+*/
+
+impl MouseScrollEvent for Input {
+    fn from_xy(x: f64, y: f64, _old_event: &Self) -> Option<Self> {
+        Some(Input::Move(Motion::MouseScroll(x, y)))
+    }
+
+    fn mouse_scroll<U, F>(&self, mut f: F) -> Option<U>
+        where F: FnMut(f64, f64) -> U
+    {
+        match *self {
+            Input::Move(Motion::MouseScroll(x, y)) => Some(f(x, y)),
+            _ => None
+        }
+    }
+}
+
+// TODO: Add impl for `Event<Input>` when specialization gets stable.
+impl<I: GenericEvent> MouseScrollEvent for Event<I> {
     fn from_xy(x: f64, y: f64, old_event: &Self) -> Option<Self> {
         GenericEvent::from_args(MOUSE_SCROLL, &(x, y) as &Any, old_event)
     }

--- a/src/input/src/mouse.rs
+++ b/src/input/src/mouse.rs
@@ -1,9 +1,7 @@
 
 //! Back-end agnostic mouse buttons.
 
-use std::any::Any;
-
-use { Event, GenericEvent, Input, Motion, MOUSE_SCROLL, MOUSE_RELATIVE, MOUSE_CURSOR };
+use { Event, Input, Motion };
 
 /// Represent a mouse button.
 #[derive(Copy, Clone, RustcDecodable, RustcEncodable, PartialEq,
@@ -127,25 +125,23 @@ impl MouseCursorEvent for Input {
     }
 }
 
-// TODO: Add impl for `Event<Input>` when specialization gets stable.
-impl<I: GenericEvent> MouseCursorEvent for Event<I> {
+impl<I: MouseCursorEvent> MouseCursorEvent for Event<I> {
     fn from_xy(x: f64, y: f64, old_event: &Self) -> Option<Self> {
-        GenericEvent::from_args(MOUSE_CURSOR, &(x, y) as &Any, old_event)
+        if let &Event::Input(ref old_input) = old_event {
+            <I as MouseCursorEvent>::from_xy(x, y, old_input)
+                .map(|x| Event::Input(x))
+        } else {
+            None
+        }
     }
 
-    fn mouse_cursor<U, F>(&self, mut f: F) -> Option<U>
+    fn mouse_cursor<U, F>(&self, f: F) -> Option<U>
         where F: FnMut(f64, f64) -> U
     {
-        if self.event_id() != MOUSE_CURSOR {
-            return None;
+        match *self {
+            Event::Input(ref x) => x.mouse_cursor(f),
+            _ => None
         }
-        self.with_args(|any| {
-            if let Some(&(x, y)) = any.downcast_ref::<(f64, f64)>() {
-                Some(f(x, y))
-            } else {
-                panic!("Expected (f64, f64)")
-            }
-        })
     }
 }
 
@@ -200,25 +196,23 @@ impl MouseRelativeEvent for Input {
     }
 }
 
-// TODO: Add impl for `Event<Input>` when specialization gets stable.
-impl<I: GenericEvent> MouseRelativeEvent for Event<I> {
+impl<I: MouseRelativeEvent> MouseRelativeEvent for Event<I> {
     fn from_xy(x: f64, y: f64, old_event: &Self) -> Option<Self> {
-        GenericEvent::from_args(MOUSE_RELATIVE, &(x, y) as &Any, old_event)
+        if let &Event::Input(ref old_input) = old_event {
+            <I as MouseRelativeEvent>::from_xy(x, y, old_input)
+                .map(|x| Event::Input(x))
+        } else {
+            None
+        }
     }
 
-    fn mouse_relative<U, F>(&self, mut f: F) -> Option<U>
+    fn mouse_relative<U, F>(&self, f: F) -> Option<U>
         where F: FnMut(f64, f64) -> U
     {
-        if self.event_id() != MOUSE_RELATIVE {
-            return None;
+        match *self {
+            Event::Input(ref x) => x.mouse_relative(f),
+            _ => None
         }
-        self.with_args(|any| {
-            if let Some(&(x, y)) = any.downcast_ref::<(f64, f64)>() {
-                Some(f(x, y))
-            } else {
-                panic!("Expected (f64, f64)")
-            }
-        })
     }
 }
 
@@ -273,25 +267,23 @@ impl MouseScrollEvent for Input {
     }
 }
 
-// TODO: Add impl for `Event<Input>` when specialization gets stable.
-impl<I: GenericEvent> MouseScrollEvent for Event<I> {
+impl<I: MouseScrollEvent> MouseScrollEvent for Event<I> {
     fn from_xy(x: f64, y: f64, old_event: &Self) -> Option<Self> {
-        GenericEvent::from_args(MOUSE_SCROLL, &(x, y) as &Any, old_event)
+        if let &Event::Input(ref old_input) = old_event {
+            <I as MouseScrollEvent>::from_xy(x, y, old_input)
+                .map(|x| Event::Input(x))
+        } else {
+            None
+        }
     }
 
-    fn mouse_scroll<U, F>(&self, mut f: F) -> Option<U>
+    fn mouse_scroll<U, F>(&self, f: F) -> Option<U>
         where F: FnMut(f64, f64) -> U
     {
-        if self.event_id() != MOUSE_SCROLL {
-            return None;
+        match *self {
+            Event::Input(ref x) => x.mouse_scroll(f),
+            _ => None
         }
-        self.with_args(|any| {
-            if let Some(&(x, y)) = any.downcast_ref::<(f64, f64)>() {
-                Some(f(x, y))
-            } else {
-                panic!("Expected (f64, f64)")
-            }
-        })
     }
 }
 

--- a/src/input/src/press.rs
+++ b/src/input/src/press.rs
@@ -1,6 +1,6 @@
 use std::any::Any;
 
-use { Button, GenericEvent, PRESS };
+use { Button, Event, GenericEvent, Input, PRESS };
 
 /// The press of a button
 pub trait PressEvent: Sized {
@@ -15,7 +15,46 @@ pub trait PressEvent: Sized {
     }
 }
 
+/* TODO: Enable when specialization gets stable.
 impl<T: GenericEvent> PressEvent for T {
+    fn from_button(button: Button, old_event: &Self) -> Option<Self> {
+        GenericEvent::from_args(PRESS, &button as &Any, old_event)
+    }
+
+    fn press<U, F>(&self, mut f: F) -> Option<U>
+        where F: FnMut(Button) -> U
+    {
+        if self.event_id() != PRESS {
+            return None;
+        }
+        self.with_args(|any| {
+            if let Some(&button) = any.downcast_ref::<Button>() {
+                Some(f(button))
+            } else {
+                panic!("Expected Button")
+            }
+        })
+    }
+}
+*/
+
+impl PressEvent for Input {
+    fn from_button(button: Button, _old_event: &Self) -> Option<Self> {
+        Some(Input::Press(button))
+    }
+
+    fn press<U, F>(&self, mut f: F) -> Option<U>
+        where F: FnMut(Button) -> U
+    {
+        match *self {
+            Input::Press(button) => Some(f(button)),
+            _ => None
+        }
+    }
+}
+
+// TODO: Add impl for `Event<Input>` when specialization gets stable.
+impl<I: GenericEvent> PressEvent for Event<I> {
     fn from_button(button: Button, old_event: &Self) -> Option<Self> {
         GenericEvent::from_args(PRESS, &button as &Any, old_event)
     }

--- a/src/input/src/press.rs
+++ b/src/input/src/press.rs
@@ -1,6 +1,4 @@
-use std::any::Any;
-
-use { Button, Event, GenericEvent, Input, PRESS };
+use { Button, Event, Input };
 
 /// The press of a button
 pub trait PressEvent: Sized {
@@ -53,25 +51,23 @@ impl PressEvent for Input {
     }
 }
 
-// TODO: Add impl for `Event<Input>` when specialization gets stable.
-impl<I: GenericEvent> PressEvent for Event<I> {
+impl<I: PressEvent> PressEvent for Event<I> {
     fn from_button(button: Button, old_event: &Self) -> Option<Self> {
-        GenericEvent::from_args(PRESS, &button as &Any, old_event)
+        if let &Event::Input(ref old_input) = old_event {
+            <I as PressEvent>::from_button(button, old_input)
+                .map(|x| Event::Input(x))
+        } else {
+            None
+        }
     }
 
-    fn press<U, F>(&self, mut f: F) -> Option<U>
+    fn press<U, F>(&self, f: F) -> Option<U>
         where F: FnMut(Button) -> U
     {
-        if self.event_id() != PRESS {
-            return None;
+        match *self {
+            Event::Input(ref x) => x.press(f),
+            _ => None
         }
-        self.with_args(|any| {
-            if let Some(&button) = any.downcast_ref::<Button>() {
-                Some(f(button))
-            } else {
-                panic!("Expected Button")
-            }
-        })
     }
 }
 

--- a/src/input/src/render.rs
+++ b/src/input/src/render.rs
@@ -1,7 +1,6 @@
-use std::any::Any;
 use viewport::Viewport;
 
-use { GenericEvent, RENDER };
+use { Event, GenericEvent, Input };
 
 /// Render arguments
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -42,6 +41,7 @@ pub trait RenderEvent: Sized {
     }
 }
 
+/* TODO: Enable when specialization gets stable.
 impl<T: GenericEvent> RenderEvent for T {
     fn from_render_args(args: &RenderArgs, old_event: &Self) -> Option<Self> {
         GenericEvent::from_args(RENDER, args as &Any, old_event)
@@ -60,6 +60,34 @@ impl<T: GenericEvent> RenderEvent for T {
                 panic!("Expected RenderArgs")
             }
         })
+    }
+}
+*/
+
+impl RenderEvent for Input {
+    fn from_render_args(_args: &RenderArgs, _old_event: &Self) -> Option<Self> {
+        None
+    }
+
+    fn render<U, F>(&self, mut _f: F) -> Option<U>
+        where F: FnMut(&RenderArgs) -> U
+    {
+        None
+    }
+}
+
+impl<I: GenericEvent> RenderEvent for Event<I> {
+    fn from_render_args(args: &RenderArgs, _old_event: &Self) -> Option<Self> {
+        Some(Event::Render(*args))
+    }
+
+    fn render<U, F>(&self, mut f: F) -> Option<U>
+        where F: FnMut(&RenderArgs) -> U
+    {
+        match *self {
+            Event::Render(ref args) => Some(f(args)),
+            _ => None
+        }
     }
 }
 

--- a/src/input/src/update.rs
+++ b/src/input/src/update.rs
@@ -1,6 +1,4 @@
-use std::any::Any;
-
-use { GenericEvent, UPDATE };
+use { Event, GenericEvent, Input };
 
 /// Update arguments, such as delta time in seconds
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -26,6 +24,7 @@ pub trait UpdateEvent: Sized {
     }
 }
 
+/* TODO: Enable when specialization gets stable.
 impl<T> UpdateEvent for T where T: GenericEvent {
     fn from_update_args(args: &UpdateArgs, old_event: &Self) -> Option<Self> {
         GenericEvent::from_args(UPDATE, args as &Any, old_event)
@@ -44,6 +43,34 @@ impl<T> UpdateEvent for T where T: GenericEvent {
                 panic!("Expected UpdateArgs")
             }
         })
+    }
+}
+*/
+
+impl UpdateEvent for Input {
+    fn from_update_args(_args: &UpdateArgs, _old_event: &Self) -> Option<Self> {
+        None
+    }
+
+    fn update<U, F>(&self, mut _f: F) -> Option<U>
+        where F: FnMut(&UpdateArgs) -> U
+    {
+        None
+    }
+}
+
+impl<I: GenericEvent> UpdateEvent for Event<I> {
+    fn from_update_args(args: &UpdateArgs, _old_event: &Self) -> Option<Self> {
+        Some(Event::Update(*args))
+    }
+
+    fn update<U, F>(&self, mut f: F) -> Option<U>
+        where F: FnMut(&UpdateArgs) -> U
+    {
+        match *self {
+            Event::Update(ref args) => Some(f(args)),
+            _ => None
+        }
     }
 }
 

--- a/src/window/Cargo.toml
+++ b/src/window/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "pistoncore-window"
-version = "0.21.0"
+version = "0.22.0"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 
 [dependencies.pistoncore-input]
 path = "../input"
-version = "0.13.0"
+version = "0.14.0"
 
 [dependencies]
 shader_version = "0.2.1"


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/piston/issues/1105

Benchmarks shows significant improvement in performance.

```
Before:
test bench_event_after_render ... bench:           0 ns/iter (+/- 0)
test bench_event_focus ... bench:                 38 ns/iter (+/- 17)
test bench_input_focus ... bench:                 27 ns/iter (+/- 16)
test bench_event_idle ... bench:                   0 ns/iter (+/- 0)
test bench_event_mouse_cursor   ... bench:        58 ns/iter (+/- 19)
test bench_event_mouse_relative ... bench:        58 ns/iter (+/- 12)
test bench_event_mouse_scroll   ... bench:        67 ns/iter (+/- 37)
test bench_input_mouse_cursor   ... bench:        29 ns/iter (+/- 6)
test bench_input_mouse_relative ... bench:        34 ns/iter (+/- 7)
test bench_input_mouse_scroll   ... bench:        41 ns/iter (+/- 18)
test bench_event_press ... bench:                 40 ns/iter (+/- 8)
test bench_input_press ... bench:                 31 ns/iter (+/- 7)
test bench_event_release ... bench:               43 ns/iter (+/- 14)
test bench_input_release ... bench:               32 ns/iter (+/- 5)
test bench_event_render ... bench:                 0 ns/iter (+/- 0)
test bench_event_resize ... bench:                43 ns/iter (+/- 17)
test bench_input_resize ... bench:                35 ns/iter (+/- 9)
test bench_event_text ... bench:                 109 ns/iter (+/- 73)
test bench_input_text ... bench:                  92 ns/iter (+/- 33)
test bench_event_update ... bench:                 0 ns/iter (+/- 0)

After:

test bench_event_after_render ... bench:           0 ns/iter (+/- 0)
test bench_event_focus ... bench:                  2 ns/iter (+/- 0)
test bench_input_focus ... bench:                  2 ns/iter (+/- 0)
test bench_event_idle ... bench:                   0 ns/iter (+/- 0)
test bench_event_mouse_cursor   ... bench:         2 ns/iter (+/- 1)
test bench_event_mouse_relative ... bench:         2 ns/iter (+/- 1)
test bench_event_mouse_scroll   ... bench:         2 ns/iter (+/- 0)
test bench_input_mouse_cursor   ... bench:         2 ns/iter (+/- 0)
test bench_input_mouse_relative ... bench:         2 ns/iter (+/- 0)
test bench_input_mouse_scroll   ... bench:         2 ns/iter (+/- 0)
test bench_event_press ... bench:                  3 ns/iter (+/- 0)
test bench_input_press ... bench:                  3 ns/iter (+/- 0)
test bench_event_release ... bench:                3 ns/iter (+/- 0)
test bench_input_release ... bench:                3 ns/iter (+/- 1)
test bench_event_render ... bench:                 0 ns/iter (+/- 0)
test bench_event_resize ... bench:                 2 ns/iter (+/- 0)
test bench_input_resize ... bench:                 2 ns/iter (+/- 0)
test bench_event_text ... bench:                  31 ns/iter (+/- 1)
test bench_input_text ... bench:                  31 ns/iter (+/- 7)
test bench_event_update ... bench:                 0 ns/iter (+/- 0)
```