### PR TITLE
enhancing CI in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ rust:
   - stable
   - nightly
 script:
-  - cargo build -v
-  - cargo doc -v
+  - bash ci/script.sh
 after_success:
-  - curl http://docs.piston.rs/travis-doc-upload.sh | sh
+  - curl http://docs.piston.rs/travis-doc-upload.sh > tdu.sh && cat tdu.sh && sh tdu.sh

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -ex
+
+pushd src/input
+cargo test -v
+popd
+
+cargo build -v
+cargo doc -v


### PR DESCRIPTION
I'd like to continue to enhance the CI process if you find value in it. I noticed there were some tests in src/input/ that weren't getting run on push and thought it wouldn't hurt to run it. 

I also created a ci folder in the root where scripts that travis will run can be stored. I've seen this pattern before and it's a good way to keep the travisfile readable and still organize your CI. 

Also, curl pipe sh can lead to unexpected and unwanted results when there is a disconnect from the host. It's typical to redirect it into a file and then running the file so the remote server's connection will not be a concern. 