### PR TITLE
fixed documentation for ext_dt, wrong units

### DIFF
--- a/src/input/src/render.rs
+++ b/src/input/src/render.rs
@@ -5,7 +5,7 @@ use { Event, GenericEvent, Input };
 /// Render arguments
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct RenderArgs {
-    /// Extrapolated time in seconds, used to do smooth animation.
+    /// Extrapolated time in nanoseconds, used to do smooth animation.
     pub ext_dt: f64,
     /// The width of rendered area in points.
     pub width: u32,


### PR DESCRIPTION
Update: https://github.com/PistonDevelopers/piston/commit/2026d69332165b369ae95ccfec3217ecdde63998 seemed to unintentionally change the units from seconds to nanoseconds so I'll open up a PR for the proper fix.


----


`duration_to_f64` returns seconds, then we divide by a billion. The fix I prefer is to remove the divide by a billion so that the units is the same as dt in UpdateArgs. Maybe there is a reason for the divide.

https://github.com/PistonDevelopers/piston/blob/7394a940785fb2114fffb871f365e8c4e0d75bf4/src/event_loop/src/lib.rs#L203