### PR TITLE
Added support for event driven applications

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston"
-version = "0.30.0"
+version = "0.31.0"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",
@@ -38,4 +38,4 @@ version = "0.26.0"
 
 [dependencies.pistoncore-event_loop]
 path = "src/event_loop"
-version = "0.30.0"
+version = "0.31.0"

--- a/src/event_loop/Cargo.toml
+++ b/src/event_loop/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "pistoncore-event_loop"
-version = "0.30.0"
+version = "0.31.0"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/piston/issues/1148

- Bumped to 0.31.0

This PR adds new features to `EventSettings` to control behavior of event loop when you want to wait for input instead of receiving update events. There are two new modes, one when UPS is 0 (wait for next frame to render) and `lazy` (wait for next input event). Both modes has same max FPS as the default mode.

In addition the event loop now skips missed updates by default if the delay is more than 2 times the UPS. This can be set by `EventSettings::ups_reset`. Fixes the edge case when updates takes more than 100% CPU.