### PR TITLE
Make example properly match on Input::Render

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ In "src/main.rs", type the following code:
 
 ```Rust
 extern crate piston_window;
-
 use piston_window::*;
 
 fn main() {
@@ -42,11 +41,13 @@ fn main() {
         WindowSettings::new("Hello Piston!", [640, 480])
         .exit_on_esc(true).build().unwrap();
     while let Some(e) = window.next() {
-        window.draw_2d(&e, |c, g| {
-            clear([1.0; 4], g);
-            rectangle([1.0, 0.0, 0.0, 1.0], // red
-                      [0.0, 0.0, 100.0, 100.0],
-                      c.transform, g);
+        if let Input::Render(_) {
+            window.draw_2d(&e, |c, g| {
+                clear([1.0; 4], g);
+                rectangle([1.0, 0.0, 0.0, 1.0], // red
+                          [0.0, 0.0, 100.0, 100.0],
+                          c.transform, g);
+            }
         });
     }
 }


### PR DESCRIPTION
I was somewhat misled by this example and would not have been had this match been in place.