### PR TITLE
Redesign inputs

### DIFF
--- a/src/input/src/after_render.rs
+++ b/src/input/src/after_render.rs
@@ -1,4 +1,4 @@
-use Input;
+use {Event, Loop};
 
 /// After render arguments.
 #[derive(Copy, Clone, PartialEq, Debug, RustcDecodable, RustcEncodable)]
@@ -16,16 +16,16 @@ pub trait AfterRenderEvent: Sized {
     }
 }
 
-impl AfterRenderEvent for Input {
-    fn from_after_render_args(args: &AfterRenderArgs, _old_event: &Input) -> Option<Self> {
-        Some(Input::AfterRender(*args))
+impl AfterRenderEvent for Event {
+    fn from_after_render_args(args: &AfterRenderArgs, _old_event: &Self) -> Option<Self> {
+        Some(Event::Loop(Loop::AfterRender(*args)))
     }
 
     fn after_render<U, F>(&self, mut f: F) -> Option<U>
         where F: FnMut(&AfterRenderArgs) -> U
     {
         match *self {
-            Input::AfterRender(ref args) => Some(f(args)),
+            Event::Loop(Loop::AfterRender(ref args)) => Some(f(args)),
             _ => None,
         }
     }
@@ -37,12 +37,11 @@ mod tests {
 
     #[test]
     fn test_input_after_render() {
-        use Input;
         use AfterRenderArgs;
 
-        let e = Input::AfterRender(AfterRenderArgs);
-        let x: Option<Input> = AfterRenderEvent::from_after_render_args(&AfterRenderArgs, &e);
-        let y: Option<Input> =
+        let e: Event = AfterRenderArgs.into();
+        let x: Option<Event> = AfterRenderEvent::from_after_render_args(&AfterRenderArgs, &e);
+        let y: Option<Event> =
             x.clone()
                 .unwrap()
                 .after_render(|args| {

--- a/src/input/src/close.rs
+++ b/src/input/src/close.rs
@@ -1,4 +1,4 @@
-use Input;
+use {Event, Input};
 
 /// Close arguments.
 #[derive(Copy, Clone, PartialEq, Debug, RustcDecodable, RustcEncodable)]
@@ -16,16 +16,16 @@ pub trait CloseEvent: Sized {
     }
 }
 
-impl CloseEvent for Input {
-    fn from_close_args(args: &CloseArgs, _old_event: &Input) -> Option<Self> {
-        Some(Input::Close(*args))
+impl CloseEvent for Event {
+    fn from_close_args(args: &CloseArgs, _old_event: &Self) -> Option<Self> {
+        Some(Event::Input(Input::Close(*args)))
     }
 
     fn close<U, F>(&self, mut f: F) -> Option<U>
         where F: FnMut(&CloseArgs) -> U
     {
         match *self {
-            Input::Close(ref args) => Some(f(args)),
+            Event::Input(Input::Close(ref args)) => Some(f(args)),
             _ => None,
         }
     }
@@ -37,12 +37,12 @@ mod tests {
 
     #[test]
     fn test_input_close() {
-        use Input;
         use CloseArgs;
+        use Event;
 
-        let e = Input::Close(CloseArgs);
-        let x: Option<Input> = CloseEvent::from_close_args(&CloseArgs, &e);
-        let y: Option<Input> = x.clone()
+        let e: Event = CloseArgs.into();
+        let x: Option<Event> = CloseEvent::from_close_args(&CloseArgs, &e);
+        let y: Option<Event> = x.clone()
             .unwrap()
             .close(|args| CloseEvent::from_close_args(args, x.as_ref().unwrap()))
             .unwrap();

--- a/src/input/src/controller.rs
+++ b/src/input/src/controller.rs
@@ -1,7 +1,7 @@
 
 //! Back-end agnostic controller events.
 
-use {Input, Motion};
+use {Event, Input, Motion};
 
 /// Components of a controller button event. Not guaranteed consistent across
 /// backends.
@@ -61,16 +61,16 @@ pub trait ControllerAxisEvent: Sized {
     }
 }
 
-impl ControllerAxisEvent for Input {
+impl ControllerAxisEvent for Event {
     fn from_controller_axis_args(args: ControllerAxisArgs, _old_event: &Self) -> Option<Self> {
-        Some(Input::Move(Motion::ControllerAxis(args)))
+        Some(Event::Input(Input::Move(Motion::ControllerAxis(args))))
     }
 
     fn controller_axis<U, F>(&self, mut f: F) -> Option<U>
         where F: FnMut(ControllerAxisArgs) -> U
     {
         match *self {
-            Input::Move(Motion::ControllerAxis(args)) => Some(f(args)),
+            Event::Input(Input::Move(Motion::ControllerAxis(args))) => Some(f(args)),
             _ => None,
         }
     }
@@ -82,12 +82,10 @@ mod controller_axis_tests {
 
     #[test]
     fn test_input_controller_axis() {
-        use super::super::{Input, Motion};
-
-        let e = Input::Move(Motion::ControllerAxis(ControllerAxisArgs::new(0, 1, 0.9)));
-        let a: Option<Input> =
+        let e: Event = ControllerAxisArgs::new(0, 1, 0.9).into();
+        let a: Option<Event> =
             ControllerAxisEvent::from_controller_axis_args(ControllerAxisArgs::new(0, 1, 0.9), &e);
-        let b: Option<Input> = a.clone()
+        let b: Option<Event> = a.clone()
             .unwrap()
             .controller_axis(|cnt| {
                 ControllerAxisEvent::from_controller_axis_args(

--- a/src/input/src/cursor.rs
+++ b/src/input/src/cursor.rs
@@ -1,4 +1,4 @@
-use Input;
+use {Event, Input};
 
 /// When window gets or loses cursor
 pub trait CursorEvent: Sized {
@@ -12,16 +12,16 @@ pub trait CursorEvent: Sized {
     }
 }
 
-impl CursorEvent for Input {
+impl CursorEvent for Event {
     fn from_cursor(cursor: bool, _old_event: &Self) -> Option<Self> {
-        Some(Input::Cursor(cursor))
+        Some(Event::Input(Input::Cursor(cursor)))
     }
 
     fn cursor<U, F>(&self, mut f: F) -> Option<U>
         where F: FnMut(bool) -> U
     {
         match *self {
-            Input::Cursor(val) => Some(f(val)),
+            Event::Input(Input::Cursor(val)) => Some(f(val)),
             _ => None,
         }
     }
@@ -35,9 +35,9 @@ mod tests {
     fn test_input_cursor() {
         use super::super::Input;
 
-        let e = Input::Cursor(false);
-        let x: Option<Input> = CursorEvent::from_cursor(true, &e);
-        let y: Option<Input> = x.clone()
+        let e: Event = Input::Cursor(false).into();
+        let x: Option<Event> = CursorEvent::from_cursor(true, &e);
+        let y: Option<Event> = x.clone()
             .unwrap()
             .cursor(|cursor| CursorEvent::from_cursor(cursor, x.as_ref().unwrap()))
             .unwrap();

--- a/src/input/src/focus.rs
+++ b/src/input/src/focus.rs
@@ -1,4 +1,4 @@
-use Input;
+use {Event, Input};
 
 /// When window gets or loses focus
 pub trait FocusEvent: Sized {
@@ -12,16 +12,16 @@ pub trait FocusEvent: Sized {
     }
 }
 
-impl FocusEvent for Input {
+impl FocusEvent for Event {
     fn from_focused(focused: bool, _old_event: &Self) -> Option<Self> {
-        Some(Input::Focus(focused))
+        Some(Event::Input(Input::Focus(focused)))
     }
 
     fn focus<U, F>(&self, mut f: F) -> Option<U>
         where F: FnMut(bool) -> U
     {
         match *self {
-            Input::Focus(focused) => Some(f(focused)),
+            Event::Input(Input::Focus(focused)) => Some(f(focused)),
             _ => None,
         }
     }
@@ -35,9 +35,9 @@ mod tests {
     fn test_input_focus() {
         use super::super::Input;
 
-        let e = Input::Focus(false);
-        let x: Option<Input> = FocusEvent::from_focused(true, &e);
-        let y: Option<Input> = x.clone()
+        let e: Event = Input::Focus(false).into();
+        let x: Option<Event> = FocusEvent::from_focused(true, &e);
+        let y: Option<Event> = x.clone()
             .unwrap()
             .focus(|focused| FocusEvent::from_focused(focused, x.as_ref().unwrap()))
             .unwrap();

--- a/src/input/src/idle.rs
+++ b/src/input/src/idle.rs
@@ -1,4 +1,4 @@
-use Input;
+use {Event, Loop};
 
 /// Idle arguments, such as expected idle time in seconds.
 #[derive(Copy, Clone, PartialEq, Debug, RustcDecodable, RustcEncodable)]
@@ -23,17 +23,16 @@ pub trait IdleEvent: Sized {
     }
 }
 
-
-impl IdleEvent for Input {
+impl IdleEvent for Event {
     fn from_idle_args(args: &IdleArgs, _old_event: &Self) -> Option<Self> {
-        Some(Input::Idle(*args))
+        Some(Event::Loop(Loop::Idle(*args)))
     }
 
     fn idle<U, F>(&self, mut f: F) -> Option<U>
         where F: FnMut(&IdleArgs) -> U
     {
         match *self {
-            Input::Idle(ref args) => Some(f(args)),
+            Event::Loop(Loop::Idle(ref args)) => Some(f(args)),
             _ => None,
         }
     }
@@ -45,12 +44,11 @@ mod tests {
 
     #[test]
     fn test_input_idle() {
-        use Input;
         use IdleArgs;
 
-        let e = Input::Idle(IdleArgs { dt: 1.0 });
-        let x: Option<Input> = IdleEvent::from_idle_args(&IdleArgs { dt: 1.0 }, &e);
-        let y: Option<Input> = x.clone()
+        let e: Event = IdleArgs { dt: 1.0 }.into();
+        let x: Option<Event> = IdleEvent::from_idle_args(&IdleArgs { dt: 1.0 }, &e);
+        let y: Option<Event> = x.clone()
             .unwrap()
             .idle(|args| IdleEvent::from_idle_args(args, x.as_ref().unwrap()))
             .unwrap();

--- a/src/input/src/mouse.rs
+++ b/src/input/src/mouse.rs
@@ -1,7 +1,7 @@
 
 //! Back-end agnostic mouse buttons.
 
-use {Input, Motion};
+use {Event, Input, Motion};
 
 /// Represent a mouse button.
 #[derive(Copy, Clone, RustcDecodable, RustcEncodable, PartialEq,
@@ -86,16 +86,16 @@ pub trait MouseCursorEvent: Sized {
     }
 }
 
-impl MouseCursorEvent for Input {
+impl MouseCursorEvent for Event {
     fn from_xy(x: f64, y: f64, _old_event: &Self) -> Option<Self> {
-        Some(Input::Move(Motion::MouseCursor(x, y)))
+        Some(Event::Input(Input::Move(Motion::MouseCursor(x, y))))
     }
 
     fn mouse_cursor<U, F>(&self, mut f: F) -> Option<U>
         where F: FnMut(f64, f64) -> U
     {
         match *self {
-            Input::Move(Motion::MouseCursor(x, y)) => Some(f(x, y)),
+            Event::Input(Input::Move(Motion::MouseCursor(x, y))) => Some(f(x, y)),
             _ => None,
         }
     }
@@ -113,16 +113,16 @@ pub trait MouseRelativeEvent: Sized {
     }
 }
 
-impl MouseRelativeEvent for Input {
+impl MouseRelativeEvent for Event {
     fn from_xy(x: f64, y: f64, _old_event: &Self) -> Option<Self> {
-        Some(Input::Move(Motion::MouseRelative(x, y)))
+        Some(Event::Input(Input::Move(Motion::MouseRelative(x, y))))
     }
 
     fn mouse_relative<U, F>(&self, mut f: F) -> Option<U>
         where F: FnMut(f64, f64) -> U
     {
         match *self {
-            Input::Move(Motion::MouseRelative(x, y)) => Some(f(x, y)),
+            Event::Input(Input::Move(Motion::MouseRelative(x, y))) => Some(f(x, y)),
             _ => None,
         }
     }
@@ -140,16 +140,16 @@ pub trait MouseScrollEvent: Sized {
     }
 }
 
-impl MouseScrollEvent for Input {
+impl MouseScrollEvent for Event {
     fn from_xy(x: f64, y: f64, _old_event: &Self) -> Option<Self> {
-        Some(Input::Move(Motion::MouseScroll(x, y)))
+        Some(Event::Input(Input::Move(Motion::MouseScroll(x, y))))
     }
 
     fn mouse_scroll<U, F>(&self, mut f: F) -> Option<U>
         where F: FnMut(f64, f64) -> U
     {
         match *self {
-            Input::Move(Motion::MouseScroll(x, y)) => Some(f(x, y)),
+            Event::Input(Input::Move(Motion::MouseScroll(x, y))) => Some(f(x, y)),
             _ => None,
         }
     }
@@ -161,11 +161,11 @@ mod mouse_event_tests {
 
     #[test]
     fn test_input_mouse_cursor() {
-        use super::super::{Input, Motion};
+        use super::super::Motion;
 
-        let e = Input::Move(Motion::MouseCursor(0.0, 0.0));
-        let a: Option<Input> = MouseCursorEvent::from_xy(1.0, 0.0, &e);
-        let b: Option<Input> = a.clone()
+        let e: Event = Motion::MouseCursor(0.0, 0.0).into();
+        let a: Option<Event> = MouseCursorEvent::from_xy(1.0, 0.0, &e);
+        let b: Option<Event> = a.clone()
             .unwrap()
             .mouse_cursor(|x, y| MouseCursorEvent::from_xy(x, y, a.as_ref().unwrap()))
             .unwrap();
@@ -174,11 +174,11 @@ mod mouse_event_tests {
 
     #[test]
     fn test_input_mouse_relative() {
-        use super::super::{Input, Motion};
+        use super::super::Motion;
 
-        let e = Input::Move(Motion::MouseRelative(0.0, 0.0));
-        let a: Option<Input> = MouseRelativeEvent::from_xy(1.0, 0.0, &e);
-        let b: Option<Input> = a.clone()
+        let e: Event = Motion::MouseRelative(0.0, 0.0).into();
+        let a: Option<Event> = MouseRelativeEvent::from_xy(1.0, 0.0, &e);
+        let b: Option<Event> = a.clone()
             .unwrap()
             .mouse_relative(|x, y| MouseRelativeEvent::from_xy(x, y, a.as_ref().unwrap()))
             .unwrap();
@@ -187,11 +187,11 @@ mod mouse_event_tests {
 
     #[test]
     fn test_input_mouse_scroll() {
-        use super::super::{Input, Motion};
+        use super::super::Motion;
 
-        let e = Input::Move(Motion::MouseScroll(0.0, 0.0));
-        let a: Option<Input> = MouseScrollEvent::from_xy(1.0, 0.0, &e);
-        let b: Option<Input> = a.clone()
+        let e: Event = Motion::MouseScroll(0.0, 0.0).into();
+        let a: Option<Event> = MouseScrollEvent::from_xy(1.0, 0.0, &e);
+        let b: Option<Event> = a.clone()
             .unwrap()
             .mouse_scroll(|x, y| MouseScrollEvent::from_xy(x, y, a.as_ref().unwrap()))
             .unwrap();

--- a/src/input/src/press.rs
+++ b/src/input/src/press.rs
@@ -1,4 +1,4 @@
-use {Button, Input};
+use {Button, Event, Input};
 
 /// The press of a button
 pub trait PressEvent: Sized {
@@ -12,16 +12,16 @@ pub trait PressEvent: Sized {
     }
 }
 
-impl PressEvent for Input {
+impl PressEvent for Event {
     fn from_button(button: Button, _old_event: &Self) -> Option<Self> {
-        Some(Input::Press(button))
+        Some(Event::Input(Input::Press(button)))
     }
 
     fn press<U, F>(&self, mut f: F) -> Option<U>
         where F: FnMut(Button) -> U
     {
         match *self {
-            Input::Press(button) => Some(f(button)),
+            Event::Input(Input::Press(button)) => Some(f(button)),
             _ => None,
         }
     }
@@ -35,10 +35,10 @@ mod tests {
     fn test_input_press() {
         use super::super::{Button, Key, Input};
 
-        let e = Input::Press(Button::Keyboard(Key::S));
+        let e: Event = Input::Press(Key::S.into()).into();
         let button = Button::Keyboard(Key::A);
-        let x: Option<Input> = PressEvent::from_button(button, &e);
-        let y: Option<Input> = x.clone()
+        let x: Option<Event> = PressEvent::from_button(button, &e);
+        let y: Option<Event> = x.clone()
             .unwrap()
             .press(|button| PressEvent::from_button(button, x.as_ref().unwrap()))
             .unwrap();

--- a/src/input/src/release.rs
+++ b/src/input/src/release.rs
@@ -1,4 +1,4 @@
-use {Button, Input};
+use {Button, Event, Input};
 
 /// The release of a button
 pub trait ReleaseEvent: Sized {
@@ -12,16 +12,16 @@ pub trait ReleaseEvent: Sized {
     }
 }
 
-impl ReleaseEvent for Input {
+impl ReleaseEvent for Event {
     fn from_button(button: Button, _old_event: &Self) -> Option<Self> {
-        Some(Input::Release(button))
+        Some(Event::Input(Input::Release(button)))
     }
 
     fn release<U, F>(&self, mut f: F) -> Option<U>
         where F: FnMut(Button) -> U
     {
         match *self {
-            Input::Release(button) => Some(f(button)),
+            Event::Input(Input::Release(button)) => Some(f(button)),
             _ => None,
         }
     }
@@ -35,10 +35,10 @@ mod tests {
     fn test_input_release() {
         use super::super::{Button, Key, Input};
 
-        let e = Input::Release(Button::Keyboard(Key::S));
+        let e: Event = Input::Release(Key::S.into()).into();
         let button = Button::Keyboard(Key::A);
-        let x: Option<Input> = ReleaseEvent::from_button(button, &e);
-        let y: Option<Input> = x.clone()
+        let x: Option<Event> = ReleaseEvent::from_button(button, &e);
+        let y: Option<Event> = x.clone()
             .unwrap()
             .release(|button| ReleaseEvent::from_button(button, x.as_ref().unwrap()))
             .unwrap();

--- a/src/input/src/render.rs
+++ b/src/input/src/render.rs
@@ -1,6 +1,6 @@
 use viewport::Viewport;
 
-use Input;
+use {Event, Loop};
 
 /// Render arguments
 #[derive(Copy, Clone, PartialEq, Debug, RustcDecodable, RustcEncodable)]
@@ -40,16 +40,16 @@ pub trait RenderEvent: Sized {
     }
 }
 
-impl RenderEvent for Input {
+impl RenderEvent for Event {
     fn from_render_args(args: &RenderArgs, _old_event: &Self) -> Option<Self> {
-        Some(Input::Render(*args))
+        Some(Event::Loop(Loop::Render(*args)))
     }
 
     fn render<U, F>(&self, mut f: F) -> Option<U>
         where F: FnMut(&RenderArgs) -> U
     {
         match *self {
-            Input::Render(ref args) => Some(f(args)),
+            Event::Loop(Loop::Render(ref args)) => Some(f(args)),
             _ => None,
         }
     }
@@ -61,17 +61,16 @@ mod tests {
 
     #[test]
     fn test_input_render() {
-        use Input;
         use RenderArgs;
 
-        let e = Input::Render(RenderArgs {
+        let e: Event = RenderArgs {
             ext_dt: 0.0,
             width: 0,
             height: 0,
             draw_width: 0,
             draw_height: 0,
-        });
-        let x: Option<Input> = RenderEvent::from_render_args(&RenderArgs {
+        }.into();
+        let x: Option<Event> = RenderEvent::from_render_args(&RenderArgs {
                                                                  ext_dt: 1.0,
                                                                  width: 10,
                                                                  height: 10,
@@ -79,7 +78,7 @@ mod tests {
                                                                  draw_height: 10,
                                                              },
                                                              &e);
-        let y: Option<Input> = x.clone()
+        let y: Option<Event> = x.clone()
             .unwrap()
             .render(|args| RenderEvent::from_render_args(args, x.as_ref().unwrap()))
             .unwrap();

--- a/src/input/src/resize.rs
+++ b/src/input/src/resize.rs
@@ -1,4 +1,4 @@
-use Input;
+use {Event, Input};
 
 /// When the window is resized
 pub trait ResizeEvent: Sized {
@@ -12,16 +12,16 @@ pub trait ResizeEvent: Sized {
     }
 }
 
-impl ResizeEvent for Input {
+impl ResizeEvent for Event {
     fn from_width_height(w: u32, h: u32, _old_event: &Self) -> Option<Self> {
-        Some(Input::Resize(w, h))
+        Some(Event::Input(Input::Resize(w, h)))
     }
 
     fn resize<U, F>(&self, mut f: F) -> Option<U>
         where F: FnMut(u32, u32) -> U
     {
         match *self {
-            Input::Resize(w, h) => Some(f(w, h)),
+            Event::Input(Input::Resize(w, h)) => Some(f(w, h)),
             _ => None,
         }
     }
@@ -35,9 +35,9 @@ mod tests {
     fn test_input_resize() {
         use super::super::Input;
 
-        let e = Input::Resize(0, 0);
-        let x: Option<Input> = ResizeEvent::from_width_height(100, 100, &e);
-        let y: Option<Input> = x.clone()
+        let e: Event = Input::Resize(0, 0).into();
+        let x: Option<Event> = ResizeEvent::from_width_height(100, 100, &e);
+        let y: Option<Event> = x.clone()
             .unwrap()
             .resize(|w, h| ResizeEvent::from_width_height(w, h, x.as_ref().unwrap()))
             .unwrap();

--- a/src/input/src/text.rs
+++ b/src/input/src/text.rs
@@ -1,6 +1,6 @@
 use std::borrow::ToOwned;
 
-use Input;
+use {Event, Input};
 
 /// When receiving text from user, such as typing a character
 pub trait TextEvent: Sized {
@@ -14,16 +14,16 @@ pub trait TextEvent: Sized {
     }
 }
 
-impl TextEvent for Input {
+impl TextEvent for Event {
     fn from_text(text: &str, _old_event: &Self) -> Option<Self> {
-        Some(Input::Text(text.into()))
+        Some(Event::Input(Input::Text(text.into())))
     }
 
     fn text<U, F>(&self, mut f: F) -> Option<U>
         where F: FnMut(&str) -> U
     {
         match *self {
-            Input::Text(ref s) => Some(f(s)),
+            Event::Input(Input::Text(ref s)) => Some(f(s)),
             _ => None,
         }
     }
@@ -37,9 +37,9 @@ mod tests {
     fn test_input_text() {
         use super::super::Input;
 
-        let e = Input::Text("".to_string());
-        let x: Option<Input> = TextEvent::from_text("hello", &e);
-        let y: Option<Input> = x.clone()
+        let e: Event = Input::Text("".to_string()).into();
+        let x: Option<Event> = TextEvent::from_text("hello", &e);
+        let y: Option<Event> = x.clone()
             .unwrap()
             .text(|text| TextEvent::from_text(text, x.as_ref().unwrap()))
             .unwrap();

--- a/src/input/src/touch.rs
+++ b/src/input/src/touch.rs
@@ -1,4 +1,4 @@
-use {Input, Motion};
+use {Event, Input, Motion};
 
 /// Stores the touch state.
 #[derive(Copy, Clone, RustcDecodable, RustcEncodable, PartialEq, Debug)]
@@ -124,16 +124,16 @@ pub trait TouchEvent: Sized {
     }
 }
 
-impl TouchEvent for Input {
+impl TouchEvent for Event {
     fn from_touch_args(args: &TouchArgs, _old_event: &Self) -> Option<Self> {
-        Some(Input::Move(Motion::Touch(*args)))
+        Some(Event::Input(Input::Move(Motion::Touch(*args))))
     }
 
     fn touch<U, F>(&self, mut f: F) -> Option<U>
         where F: FnMut(&TouchArgs) -> U
     {
         match *self {
-            Input::Move(Motion::Touch(ref args)) => Some(f(args)),
+            Event::Input(Input::Move(Motion::Touch(ref args))) => Some(f(args)),
             _ => None,
         }
     }
@@ -145,13 +145,11 @@ mod tests {
 
     #[test]
     fn test_input_touch() {
-        use super::super::{Input, Motion};
-
         let pos = [0.0; 2];
-        let e = Input::Move(Motion::Touch(TouchArgs::new(0, 0, pos, 1.0, Touch::Start)));
-        let a: Option<Input> =
+        let e: Event = TouchArgs::new(0, 0, pos, 1.0, Touch::Start).into();
+        let a: Option<Event> =
             TouchEvent::from_touch_args(&TouchArgs::new(0, 0, pos, 1.0, Touch::Start), &e);
-        let b: Option<Input> = a.clone()
+        let b: Option<Event> = a.clone()
             .unwrap()
             .touch(|t| {
                 TouchEvent::from_touch_args(&TouchArgs::new(t.device,
@@ -167,14 +165,14 @@ mod tests {
 
     #[test]
     fn test_input_touch_3d() {
-        use super::super::{Input, Motion};
+        use super::super::Event;
 
         let pos = [0.0; 3];
         let pressure = [0.0, 0.0, 1.0];
-        let e = Input::Move(Motion::Touch(TouchArgs::new_3d(0, 0, pos, pressure, Touch::Start)));
-        let a: Option<Input> =
+        let e: Event = TouchArgs::new_3d(0, 0, pos, pressure, Touch::Start).into();
+        let a: Option<Event> =
             TouchEvent::from_touch_args(&TouchArgs::new_3d(0, 0, pos, pressure, Touch::Start), &e);
-        let b: Option<Input> = a.clone()
+        let b: Option<Event> = a.clone()
             .unwrap()
             .touch(|t| {
                 TouchEvent::from_touch_args(&TouchArgs::new_3d(t.device,

--- a/src/input/src/update.rs
+++ b/src/input/src/update.rs
@@ -1,4 +1,4 @@
-use Input;
+use {Event, Loop};
 
 /// Update arguments, such as delta time in seconds
 #[derive(Copy, Clone, PartialEq, Debug, RustcDecodable, RustcEncodable)]
@@ -23,16 +23,16 @@ pub trait UpdateEvent: Sized {
     }
 }
 
-impl UpdateEvent for Input {
+impl UpdateEvent for Event {
     fn from_update_args(args: &UpdateArgs, _old_event: &Self) -> Option<Self> {
-        Some(Input::Update(*args))
+        Some(Event::Loop(Loop::Update(*args)))
     }
 
     fn update<U, F>(&self, mut f: F) -> Option<U>
         where F: FnMut(&UpdateArgs) -> U
     {
         match *self {
-            Input::Update(ref args) => Some(f(args)),
+            Event::Loop(Loop::Update(ref args)) => Some(f(args)),
             _ => None,
         }
     }
@@ -44,12 +44,12 @@ mod tests {
 
     #[test]
     fn test_input_update() {
-        use Input;
+        use Event;
         use UpdateArgs;
 
-        let e = Input::Update(UpdateArgs { dt: 0.0 });
-        let x: Option<Input> = UpdateEvent::from_update_args(&UpdateArgs { dt: 1.0 }, &e);
-        let y: Option<Input> = x.clone()
+        let e: Event = UpdateArgs { dt: 0.0 }.into();
+        let x: Option<Event> = UpdateEvent::from_update_args(&UpdateArgs { dt: 1.0 }, &e);
+        let y: Option<Event> = x.clone()
             .unwrap()
             .update(|args| UpdateEvent::from_update_args(args, x.as_ref().unwrap()))
             .unwrap();


### PR DESCRIPTION
See discussion https://github.com/PistonDevelopers/piston/issues/1187.

- Added `Event` enum
- Moved custom events to `Event`
- Added `Loop` enum
- Moved loop events to `Loop`
- Implement `GenericEvent` only for `Event`
- Require `Into<Option<Input>>` and `Into<Option<Loop>>` on
`GenericEvent`
- Added some conversion implementations
- Updated tests