### PR TITLE
Support for SDL2 style controller hats

### DIFF
--- a/src/input/src/controller.rs
+++ b/src/input/src/controller.rs
@@ -24,6 +24,27 @@ impl ControllerButton {
     }
 }
 
+/// Components of a controller hat move event (d-Pad).
+#[derive(Copy, Clone, Deserialize, Serialize, PartialEq, Eq, Debug, Hash)]
+pub struct ControllerHat {
+  /// Which Controller was the button on.
+  pub id: i32,
+  /// Which button was pressed.
+  pub state: ::HatState,
+  /// Which hat on the controller was changed
+  pub which: u8,
+}
+
+impl ControllerHat {
+    /// Create a new ControllerButton object. Intended for use by backends when
+    /// emitting events.
+  pub fn new(id: i32, which: u8, state: ::HatState) -> Self {
+    ControllerHat {
+      id, state, which,
+    }
+  }
+}
+
 /// Components of a controller axis move event. Not guaranteed consistent across
 /// backends.
 #[derive(Copy, Clone, Deserialize, Serialize, PartialEq, Debug)]

--- a/src/input/src/controller.rs
+++ b/src/input/src/controller.rs
@@ -36,8 +36,8 @@ pub struct ControllerHat {
 }
 
 impl ControllerHat {
-    /// Create a new ControllerButton object. Intended for use by backends when
-    /// emitting events.
+  /// Create a new ControllerButton object. Intended for use by backends when
+  /// emitting events.
   pub fn new(id: i32, which: u8, state: ::HatState) -> Self {
     ControllerHat {
       id, state, which,

--- a/src/input/src/lib.rs
+++ b/src/input/src/lib.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 pub use mouse::MouseButton;
 pub use keyboard::Key;
-pub use controller::{ControllerAxisArgs, ControllerButton};
+pub use controller::{ControllerAxisArgs, ControllerButton, ControllerHat};
 
 pub mod controller;
 pub mod keyboard;
@@ -82,6 +82,8 @@ pub enum Button {
     Mouse(MouseButton),
     /// A controller button.
     Controller(ControllerButton),
+    /// A controller hat (d-Pad)
+    Hat(ControllerHat),
 }
 
 /// Models different kinds of motion.
@@ -97,6 +99,20 @@ pub enum Motion {
     ControllerAxis(ControllerAxisArgs),
     /// touch event.
     Touch(TouchArgs),
+}
+
+#[derive(Copy, Clone, Deserialize, Serialize, PartialEq, Eq, Debug, Hash)]
+#[allow(missing_docs)]
+pub enum HatState {
+  Centered,
+  Up,
+  Right,
+  Down,
+  Left,
+  RightUp,
+  RightDown,
+  LeftUp,
+  LeftDown,
 }
 
 /// Models input events.


### PR DESCRIPTION
This commit added a few things related to more fully support X-box controllers via the sdl2_window backend (related to the issue #206 on the sdl2_window repository [1] . I used the stuff introduced here to fix issue #206 there, you should be able to see that in my fork of sdl2_window. If/When this PR gets accepted I'll open a PR for that as well)

[1] https://github.com/PistonDevelopers/sdl2_window/issues/206