### PR TITLE
README.md: update piston_window version in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add [piston_window](https://crates.io/crates/piston_window) to your Cargo.toml, 
 
 ```toml
 [dependencies]
-piston_window = "0.70.0"
+piston_window = "0.81.0"
 ```
 
 In "src/main.rs", type the following code:


### PR DESCRIPTION
I noticed that the `piston_window` crate in the README was out of date, so this PR brings it to the latest version in the [GitHub repo](https://github.com/pistondevelopers/piston_window).

I tested the example code with the newer crate, and it compiles and runs without issue.