### PR TITLE
Add `FileDrag` to the `Input` enum

### DIFF
--- a/src/input/src/generic_event.rs
+++ b/src/input/src/generic_event.rs
@@ -7,7 +7,7 @@ use {AfterRenderEvent, ButtonEvent, CloseEvent, ControllerAxisEvent, CursorEvent
      RenderEvent, ResizeEvent, TextEvent, TouchEvent, UpdateEvent};
 use {Event, EventId, Input, Loop, Motion};
 use {AFTER_RENDER, BUTTON, CONTROLLER_AXIS, CURSOR, FOCUS, CLOSE, IDLE, MOUSE_CURSOR, MOUSE_RELATIVE,
-     MOUSE_SCROLL, RENDER, RESIZE, TEXT, TOUCH, UPDATE};
+     MOUSE_SCROLL, RENDER, RESIZE, TEXT, TOUCH, UPDATE, FILE_DRAG};
 
 /// Implemented by all events
 pub trait GenericEvent: Sized +
@@ -38,6 +38,7 @@ impl GenericEvent for Event {
             Event::Input(Input::Button(_)) => BUTTON,
             Event::Input(Input::Resize(_, _)) => RESIZE,
             Event::Input(Input::Text(_)) => TEXT,
+            Event::Input(Input::FileDrag(_)) => FILE_DRAG,
             Event::Loop(Loop::Update(_)) => UPDATE,
             Event::Loop(Loop::Render(_)) => RENDER,
             Event::Loop(Loop::AfterRender(_)) => AFTER_RENDER,
@@ -61,6 +62,7 @@ impl GenericEvent for Event {
             Event::Input(Input::Button(ref args)) => f(args as &Any),
             Event::Input(Input::Resize(w, h)) => f(&(w, h) as &Any),
             Event::Input(Input::Text(ref text)) => f(text as &Any),
+            Event::Input(Input::FileDrag(ref file_drag)) => f(file_drag as &Any),
             Event::Loop(Loop::Update(ref args)) => f(args as &Any),
             Event::Loop(Loop::Render(ref args)) => f(args as &Any),
             Event::Loop(Loop::AfterRender(ref args)) => f(args as &Any),

--- a/src/input/src/lib.rs
+++ b/src/input/src/lib.rs
@@ -15,6 +15,7 @@ extern crate viewport;
 use std::fmt;
 use std::any::Any;
 use std::sync::Arc;
+use std::path::PathBuf;
 
 pub use mouse::MouseButton;
 pub use keyboard::Key;
@@ -72,6 +73,7 @@ const RESIZE: EventId = EventId("piston/resize");
 const TEXT: EventId = EventId("piston/text");
 const TOUCH: EventId = EventId("piston/touch");
 const UPDATE: EventId = EventId("piston/update");
+const FILE_DRAG: EventId = EventId("piston/file_drag");
 
 /// Models different kinds of buttons.
 #[derive(Copy, Clone, Deserialize, Serialize, PartialEq, Eq, Hash, Debug)]
@@ -115,6 +117,17 @@ pub enum HatState {
   LeftDown,
 }
 
+/// Models dragging and dropping files.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub enum FileDrag {
+    /// A file is being hovered over the window.
+    Hovered(PathBuf),
+    /// A file has been dropped into the window.
+    Dropped(PathBuf),
+    /// A file was hovered, but has exited the window.
+    Cancelled,
+}
+
 /// Models input events.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub enum Input {
@@ -130,6 +143,8 @@ pub enum Input {
     Focus(bool),
     /// Window gained or lost cursor.
     Cursor(bool),
+    /// A file is being dragged or dropped over the window.
+    FileDrag(FileDrag),
     /// Window closed.
     Close(CloseArgs),
 }


### PR DESCRIPTION
I wanted piston to be able to hand file drag events, so I added an enum called `FileDrag` which contains variants that mirror the file drag events of glutin. I added this enum as the only field of a new variant of `Input`, `Input::FileDrag`. I was going to add it to the `Motion` enum instead, but file dragging events include a `PathBuf`, which is not `Copy`.