### PR TITLE
Add methods to set automatic window closing

### DIFF
--- a/src/window/src/lib.rs
+++ b/src/window/src/lib.rs
@@ -284,6 +284,37 @@ pub trait AdvancedWindow: Window + Sized {
         self
     }
 
+    /// Gets whether the window will automatically close when attempting
+    /// to close it.
+    ///
+    /// Useful when prototyping.
+    fn get_automatic_close(&self) -> bool;
+
+    /// Sets whether the window will automatically close when attempting
+    /// to close it. If this is disabled, attempts to close the window
+    /// can be detected via an `Input::Close(..)` event, and
+    /// [`Window::set_should_close()`](trait.Window.html#tymethod.set_should_close)
+    /// can be called to actually close the window.
+    ///
+    /// Useful when prototyping.
+    fn set_automatic_close(&mut self, value: bool);
+
+    /// Sets whether the window will automatically close when attempting
+    /// to close it. If this is disabled, attempts to close the window
+    /// can be detected via an `Input::Close(..)` event, and
+    /// [`Window::set_should_close()`](trait.Window.html#tymethod.set_should_close)
+    /// can be called to actually close the window.
+    ///
+    /// Useful when prototyping.
+    ///
+    /// This method moves the current window data,
+    /// unlike [`set_automatic_close()`](#tymethod.set_automatic_close), so
+    /// that it can be used in method chaining.
+    fn automatic_close(mut self, value: bool) -> Self {
+        self.set_automatic_close(value);
+        self
+    }
+
     /// Sets whether to capture/grab the cursor.
     ///
     /// This is used to lock and hide cursor to the window,
@@ -377,6 +408,7 @@ pub struct WindowSettings {
     samples: u8,
     fullscreen: bool,
     exit_on_esc: bool,
+    automatic_close: bool,
     vsync: bool,
     opengl: Option<OpenGL>,
     srgb: bool,
@@ -403,6 +435,7 @@ impl WindowSettings {
             samples: 0,
             fullscreen: false,
             exit_on_esc: false,
+            automatic_close: true,
             vsync: false,
             opengl: None,
             srgb: true,
@@ -504,6 +537,35 @@ impl WindowSettings {
     /// so that it can be used in method chaining.
     pub fn exit_on_esc(mut self, value: bool) -> Self {
         self.set_exit_on_esc(value);
+        self
+    }
+
+    /// Gets whether built windows should automatically close when the X or
+    /// ALT+F4 are pressed.
+    pub fn get_automatic_close(&self) -> bool {
+        self.automatic_close
+    }
+
+    /// Sets whether built windows should automatically close when the X or
+    /// ALT+F4 are pressed. If this is disabled, attempts to close the window
+    /// can be detected via an `Input::Close(..)` event, and
+    /// [`Window::set_should_close()`](trait.Window.html#tymethod.set_should_close)
+    /// can be called to actually close the window.
+    pub fn set_automatic_close(&mut self, value: bool) {
+        self.automatic_close = value;
+    }
+
+    /// Sets whether built windows should automatically close when the X or
+    /// ALT+F4 are pressed. If this is disabled, attempts to close the window
+    /// can be detected via an `Input::Close(..)` event, and
+    /// [`Window::set_should_close()`](trait.Window.html#tymethod.set_should_close)
+    /// can be called to actually close the window.
+    ///
+    /// This method moves the current window data,
+    /// unlike [`set_automatic_close()`](#method.set_automatic_close),
+    /// so that it can be used in method chaining.
+    pub fn automatic_close(mut self, value: bool) -> Self {
+        self.set_automatic_close(value);
         self
     }
 

--- a/src/window/src/no_window.rs
+++ b/src/window/src/no_window.rs
@@ -20,6 +20,7 @@ use std::error::Error;
 /// events when the width or height is zero.
 pub struct NoWindow {
     should_close: bool,
+    automatic_close: bool,
     title: String,
     size: Size,
     pos: Position,
@@ -30,6 +31,7 @@ impl NoWindow {
     pub fn new(settings: &WindowSettings) -> NoWindow {
         NoWindow {
             should_close: false,
+            automatic_close: settings.automatic_close,
             title: settings.get_title(),
             size: settings.get_size(),
             pos: Position { x: 0, y: 0 },
@@ -92,6 +94,14 @@ impl AdvancedWindow for NoWindow {
     }
 
     fn set_exit_on_esc(&mut self, _value: bool) {}
+
+    fn get_automatic_close(&self) -> bool {
+        self.automatic_close
+    }
+
+    fn set_automatic_close(&mut self, value: bool) {
+        self.automatic_close = value;
+    }
 
     fn set_capture_cursor(&mut self, _value: bool) {}
 


### PR DESCRIPTION
The implementors of `AdvancedWindow` that I have worked with automatically close the window when the X or ALT+F4 are pressed, but this is not always desirable. For example, upon the user attempting to close the window, a game might want to display a message first that says, "Are you sure you want to quit? All unsaved progress will be lost."

I have added methods to `WindowSettings` and `AdvancedWindow` that allow an `automatic_close` value to be set. If `automatic_close` is false, implementors of `AdvancedWindow` should not close the window, but should still send an `Input::Close(..)` event. The close attempt can be processed, and if the window really should be closed, then `Window::set_should_close` can be called. I have noted all of this in the method documentation. By default, `automatic_close` on `WindowSettings` is `true` so as not to add extra event-handling overhead for the majority of use cases.