### PR TITLE
docs(README): use hyperlink for core contributor

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A modular game engine written in Rust
 
-Maintainers of Piston core libraries: @bvssvni
+Maintainers of Piston core libraries: [@bvssvni](https://github.com/bvssvni)
 
 ## Dive into the world of Piston
 * [Guide](./GUIDE.md)


### PR DESCRIPTION
I think that the core contributor should at least have a link to their GitHub for all of their hard work.